### PR TITLE
handle emergency tortoise which isn't handled by the controller as soon as possible

### DIFF
--- a/pkg/hpa/service.go
+++ b/pkg/hpa/service.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"math"
+	"strconv"
 	"time"
 
 	"github.com/mercari/tortoise/pkg/annotation"
@@ -83,13 +84,13 @@ func (c *Service) CreateHPAOnTortoise(ctx context.Context, tortoise *autoscaling
 	}
 
 	m := make([]v2.MetricSpec, 0, len(tortoise.Spec.ResourcePolicy))
-	for _, c := range tortoise.Spec.ResourcePolicy {
-		for r, p := range c.AutoscalingPolicy {
+	for _, policy := range tortoise.Spec.ResourcePolicy {
+		for r, p := range policy.AutoscalingPolicy {
 			value := resourceQuantityPtr(resource.MustParse("50"))
 			if p != autoscalingv1alpha1.AutoscalingTypeHorizontal {
-				value = resourceQuantityPtr(resource.MustParse("90"))
+				value = resourceQuantityPtr(resource.MustParse(strconv.Itoa(int(c.upperTargetResourceUtilization))))
 			}
-			externalMetricName, err := externalMetricNameFromAnnotation(hpa, c.ContainerName, r)
+			externalMetricName, err := externalMetricNameFromAnnotation(hpa, policy.ContainerName, r)
 			if err != nil {
 				return nil, tortoise, err
 			}

--- a/pkg/tortoise/tortoise.go
+++ b/pkg/tortoise/tortoise.go
@@ -47,8 +47,8 @@ func New(c client.Client, rangeOfMinMaxReplicasRecommendationHour int, timeZone 
 }
 
 func (s *Service) ShouldReconcileTortoiseNow(tortoise *v1alpha1.Tortoise, now time.Time) (bool, time.Duration) {
-	if tortoise.Spec.UpdateMode == v1alpha1.UpdateModeEmergency {
-		// If Emergency, it should be updated ASAP.
+	if tortoise.Spec.UpdateMode == v1alpha1.UpdateModeEmergency && tortoise.Status.TortoisePhase != v1alpha1.TortoisePhaseEmergency {
+		// Tortoise which is emergency mode, but hasn't been handled by the controller yet. It should be updated ASAP.
 		return true, 0
 	}
 

--- a/pkg/tortoise/tortoise_test.go
+++ b/pkg/tortoise/tortoise_test.go
@@ -579,7 +579,7 @@ func TestService_ShouldReconcileTortoiseNow(t *testing.T) {
 			wantDuration: 59 * time.Second,
 		},
 		{
-			name: "emergency mode tortoise should be updated",
+			name: "emergency mode un-handled tortoise should be updated",
 			lastTimeUpdateTortoise: map[client.ObjectKey]time.Time{
 				client.ObjectKey{Name: "t", Namespace: "default"}: now.Add(-1 * time.Second),
 			},
@@ -590,6 +590,25 @@ func TestService_ShouldReconcileTortoiseNow(t *testing.T) {
 				},
 				Spec: v1alpha1.TortoiseSpec{
 					UpdateMode: v1alpha1.UpdateModeEmergency,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "emergency mode tortoise (already handled) is treated as the usual tortoise",
+			lastTimeUpdateTortoise: map[client.ObjectKey]time.Time{
+				client.ObjectKey{Name: "t", Namespace: "default"}: now.Add(-1 * time.Second),
+			},
+			tortoise: &v1alpha1.Tortoise{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "t",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.TortoiseSpec{
+					UpdateMode: v1alpha1.UpdateModeEmergency,
+				},
+				Status: v1alpha1.TortoiseStatus{
+					TortoisePhase: v1alpha1.TortoisePhaseEmergency,
 				},
 			},
 			want: true,


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/
-->

#### What this PR does / why we need it:

When starting the reconciliation for one tortoise, the controller checks the last time that tortoise is handled, and determine if the controller reconciles the tortoise now or not.

As an exception case, emergency tortoises are handled soon because of emergency situations. So far, all `.spec.updateMode == Emergency` tortoises are handled without checking the last update time. 
But, this PR improve that logic; In emergency tortoises case, we need to focus on the tortoise which isn't handled by the controller yet. And we don't need to rush on reconciliation of emergency tortoises which is already handled (minReplicas increased) by the controller before.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
