### PR TITLE
update tortoise status before update HPA and VPA

### DIFF
--- a/controllers/tortoise_controller.go
+++ b/controllers/tortoise_controller.go
@@ -132,6 +132,12 @@ func (r *TortoiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
+	_, err = r.TortoiseService.UpdateTortoiseStatus(ctx, tortoise, now)
+	if err != nil {
+		logger.Error(err, "update Tortoise status", "tortoise", req.NamespacedName)
+		return ctrl.Result{}, err
+	}
+
 	_, tortoise, err = r.HpaService.UpdateHPAFromTortoiseRecommendation(ctx, tortoise, now)
 	if err != nil {
 		logger.Error(err, "update HPA based on the recommendation in tortoise", "tortoise", req.NamespacedName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/
-->

#### What this PR does / why we need it:

We need to update tortoise status before updating HPA and VPA so that we can prevent the data difference between the recommendation on tortoise and the actual parameters on HPA/VPA when updating tortoise status is failed.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
