### PR TITLE
validation: emergency mode is only available with tortoises with Running or BackToNormal

### DIFF
--- a/api/v1alpha1/tortoise_types.go
+++ b/api/v1alpha1/tortoise_types.go
@@ -45,7 +45,7 @@ type TortoiseSpec struct {
 	// If "Off", tortoise generates the recommendations in .Status, but doesn't apply it actually.
 	// If "Auto", tortoise generates the recommendations in .Status, and apply it to resources.
 	// If "Emergency", tortoise generates the recommendations in .Status as usual, but increase replica number high enough value.
-	// "Emergency" is useful when something unexpected happens in workloads and you want to scale up the workload with high enough resources.
+	// "Emergency" is useful when something unexpected happens in workloads, and you want to scale up the workload with high enough resources.
 	// See https://github.com/mercari/tortoise/blob/main/docs/emergency.md to know more about emergency mode.
 	//
 	// "Off" is the default value.

--- a/api/v1alpha1/tortoise_types.go
+++ b/api/v1alpha1/tortoise_types.go
@@ -45,7 +45,8 @@ type TortoiseSpec struct {
 	// If "Off", tortoise generates the recommendations in .Status, but doesn't apply it actually.
 	// If "Auto", tortoise generates the recommendations in .Status, and apply it to resources.
 	// If "Emergency", tortoise generates the recommendations in .Status as usual, but increase replica number high enough value.
-	// "Emergency" is useful when something unexpected happens in workloads.
+	// "Emergency" is useful when something unexpected happens in workloads and you want to scale up the workload with high enough resources.
+	// See https://github.com/mercari/tortoise/blob/main/docs/emergency.md to know more about emergency mode.
 	//
 	// "Off" is the default value.
 	// +optional

--- a/api/v1alpha1/tortoise_webhook.go
+++ b/api/v1alpha1/tortoise_webhook.go
@@ -126,16 +126,17 @@ func validateTortoise(t *Tortoise) error {
 		}
 	}
 
+	if t.Spec.UpdateMode == UpdateModeEmergency &&
+		t.Status.TortoisePhase != TortoisePhaseWorking && t.Status.TortoisePhase != TortoisePhaseEmergency && t.Status.TortoisePhase != TortoisePhaseBackToNormal {
+		return fmt.Errorf("%s: emergency mode is only available for tortoises with Running phase", fieldPath.Child("updateMode"))
+	}
+
 	return fmt.Errorf("%s: at least one policy should be Horizontal", fieldPath.Child("resourcePolicy", "autoscalingPolicy"))
 }
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Tortoise) ValidateCreate() error {
 	tortoiselog.Info("validate create", "name", r.Name)
-
-	if r.Spec.UpdateMode == UpdateModeEmergency {
-		return fmt.Errorf("%s: updateMode cannot be Emergency at first", field.NewPath("spec").Child("updateMode"))
-	}
 
 	return validateTortoise(r)
 }

--- a/api/v1alpha1/tortoise_webhook.go
+++ b/api/v1alpha1/tortoise_webhook.go
@@ -132,6 +132,11 @@ func validateTortoise(t *Tortoise) error {
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *Tortoise) ValidateCreate() error {
 	tortoiselog.Info("validate create", "name", r.Name)
+
+	if r.Spec.UpdateMode == UpdateModeEmergency {
+		return fmt.Errorf("%s: updateMode cannot be Emergency at first", field.NewPath("spec").Child("updateMode"))
+	}
+
 	return validateTortoise(r)
 }
 

--- a/api/v1alpha1/tortoise_webhook.go
+++ b/api/v1alpha1/tortoise_webhook.go
@@ -142,7 +142,6 @@ func (r *Tortoise) ValidateCreate() error {
 }
 
 // ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
-// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 func (r *Tortoise) ValidateUpdate(old runtime.Object) error {
 	tortoiselog.Info("validate update", "name", r.Name)
 	if err := validateTortoise(r); err != nil {
@@ -172,6 +171,7 @@ func (r *Tortoise) ValidateUpdate(old runtime.Object) error {
 }
 
 // ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+// TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.
 func (r *Tortoise) ValidateDelete() error {
 	tortoiselog.Info("validate delete", "name", r.Name)
 	return nil

--- a/config/crd/bases/autoscaling.mercari.com_tortoises.yaml
+++ b/config/crd/bases/autoscaling.mercari.com_tortoises.yaml
@@ -113,7 +113,9 @@ spec:
                   in .Status, and apply it to resources. If \"Emergency\", tortoise
                   generates the recommendations in .Status as usual, but increase
                   replica number high enough value. \"Emergency\" is useful when something
-                  unexpected happens in workloads. \n \"Off\" is the default value."
+                  unexpected happens in workloads and you want to scale up the workload
+                  with high enough resources. See https://github.com/mercari/tortoise/blob/main/docs/emergency.md
+                  to know more about emergency mode. \n \"Off\" is the default value."
                 enum:
                 - "Off"
                 - Auto

--- a/config/crd/bases/autoscaling.mercari.com_tortoises.yaml
+++ b/config/crd/bases/autoscaling.mercari.com_tortoises.yaml
@@ -113,7 +113,7 @@ spec:
                   in .Status, and apply it to resources. If \"Emergency\", tortoise
                   generates the recommendations in .Status as usual, but increase
                   replica number high enough value. \"Emergency\" is useful when something
-                  unexpected happens in workloads and you want to scale up the workload
+                  unexpected happens in workloads, and you want to scale up the workload
                   with high enough resources. See https://github.com/mercari/tortoise/blob/main/docs/emergency.md
                   to know more about emergency mode. \n \"Off\" is the default value."
                 enum:

--- a/docs/emergency.md
+++ b/docs/emergency.md
@@ -30,3 +30,8 @@ Specifically, the controller reduces `minReplicas` to the original value gradual
 ```
 
 During gradually reducing the `minReplicas`, the Tortoise is in the `BackToNormal` state.
+
+### Note
+
+Emergency mode is available for tortoises with `Running` or `BackToNormal` phase.
+(because it requires enough historical data to work on)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/
-->

#### What this PR does / why we need it:

validation: emergency mode is only available with tortoises with Running or BackToNormal

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #61 

#### Special notes for your reviewer:
