### PR TITLE
skip applying the recommendations to HPA or VPAs when GatheringData

### DIFF
--- a/controllers/tortoise_controller.go
+++ b/controllers/tortoise_controller.go
@@ -147,6 +147,11 @@ func (r *TortoiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		return ctrl.Result{}, err
 	}
 
+	if tortoise.Status.TortoisePhase == autoscalingv1alpha1.TortoisePhaseGatheringData {
+		logger.V(4).Info("tortoise is GatheringData phase; skip applying the recommendation to HPA or VPAs")
+		return ctrl.Result{}, nil
+	}
+
 	_, tortoise, err = r.HpaService.UpdateHPAFromTortoiseRecommendation(ctx, tortoise, now)
 	if err != nil {
 		logger.Error(err, "update HPA based on the recommendation in tortoise", "tortoise", req.NamespacedName)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/
-->

#### What this PR does / why we need it:

skip applying the recommendations to HPA or VPAs when GatheringData
Currently it works much similar to Working phase 😓 

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #73 

#### Special notes for your reviewer:
