### PR TITLE
feature: expose metrics about applied values

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/google/go-cmp v0.5.9
 	github.com/onsi/ginkgo/v2 v2.8.0
 	github.com/onsi/gomega v1.26.0
+	github.com/prometheus/client_golang v1.12.1
 	k8s.io/api v0.25.0
 	k8s.io/apimachinery v0.25.0
 	k8s.io/autoscaler/vertical-pod-autoscaler v0.13.0
@@ -52,7 +53,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
-	github.com/prometheus/client_golang v1.12.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,37 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	AppliedHPATargetUtilization = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "applied_hpa_utilization_target",
+		Help: "recommended hpa utilization target values that tortoises apply",
+	}, []string{"tortoise_name", "namespace", "container_name", "resource_name", "hpa_name"})
+
+	AppliedHPAMinReplicass = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "applied_hpa_minreplicas",
+		Help: "recommended hpa minReplicas that tortoises apply",
+	}, []string{"tortoise_name", "namespace", "hpa_name"})
+
+	AppliedHPAMaxReplicass = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "applied_hpa_maxreplicas",
+		Help: "recommended hpa maxReplicas that tortoises apply",
+	}, []string{"tortoise_name", "namespace", "hpa_name"})
+
+	AppliedResourceRequest = prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "applied_resource_request",
+		Help: "recommended cpu request that tortoises apply",
+	}, []string{"tortoise_name", "namespace", "container_name", "resource_name"})
+)
+
+func init() {
+	//Register metrics with prometheus
+	prometheus.MustRegister(
+		AppliedHPATargetUtilization,
+		AppliedHPAMinReplicass,
+		AppliedHPAMaxReplicass,
+		AppliedResourceRequest,
+	)
+}

--- a/pkg/vpa/service.go
+++ b/pkg/vpa/service.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/client-go/util/retry"
 
 	autoscalingv1alpha1 "github.com/mercari/tortoise/api/v1alpha1"
+	"github.com/mercari/tortoise/metrics"
 )
 
 type Service struct {
@@ -127,6 +128,9 @@ func (c *Service) UpdateVPAFromTortoiseRecommendation(ctx context.Context, torto
 		}
 		newRecommendations := make([]v1.RecommendedContainerResources, 0, len(tortoise.Status.Recommendations.Vertical.ContainerResourceRecommendation))
 		for _, r := range tortoise.Status.Recommendations.Vertical.ContainerResourceRecommendation {
+			for resourcename, value := range r.RecommendedResource {
+				metrics.AppliedResourceRequest.WithLabelValues(tortoise.Name, tortoise.Namespace, r.ContainerName, resourcename.String()).Observe(float64(value.MilliValue()))
+			}
 			newRecommendations = append(newRecommendations, v1.RecommendedContainerResources{
 				ContainerName:  r.ContainerName,
 				Target:         r.RecommendedResource,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/
-->

#### What this PR does / why we need it:

expose metrics about applied values.

```go
	AppliedHPATargetUtilization = prometheus.NewHistogramVec(prometheus.HistogramOpts{
		Name: "applied_hpa_utilization_target",
		Help: "recommended hpa utilization target values that tortoises apply",
	}, []string{"tortoise_name", "namespace", "container_name", "resource_name", "hpa_name"})

	AppliedHPAMinReplicass = prometheus.NewHistogramVec(prometheus.HistogramOpts{
		Name: "applied_hpa_minreplicas",
		Help: "recommended hpa minReplicas that tortoises apply",
	}, []string{"tortoise_name", "namespace", "hpa_name"})

	AppliedHPAMaxReplicass = prometheus.NewHistogramVec(prometheus.HistogramOpts{
		Name: "applied_hpa_maxreplicas",
		Help: "recommended hpa maxReplicas that tortoises apply",
	}, []string{"tortoise_name", "namespace", "hpa_name"})

	AppliedResourceRequest = prometheus.NewHistogramVec(prometheus.HistogramOpts{
		Name: "applied_resource_request",
		Help: "recommended cpu request that tortoises apply",
	}, []string{"tortoise_name", "namespace", "container_name", "resource_name"})
```

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #88 

#### Special notes for your reviewer:
