### PR TITLE
fix: initialize HPA correctly

### DIFF
--- a/api/v1alpha1/service.go
+++ b/api/v1alpha1/service.go
@@ -28,6 +28,7 @@ func (c *service) GetDeploymentOnTortoise(ctx context.Context, tortoise *Tortois
 
 func (c *service) GetHPAFromUser(ctx context.Context, tortoise *Tortoise) (*v2.HorizontalPodAutoscaler, error) {
 	if tortoise.Spec.TargetRefs.HorizontalPodAutoscalerName == nil {
+		// user doesn't specify HPA.
 		return nil, nil
 	}
 

--- a/api/v1alpha1/tortoise_types.go
+++ b/api/v1alpha1/tortoise_types.go
@@ -108,9 +108,8 @@ type TargetRefs struct {
 	// The target HPA should have the ContainerResource type metric or the external metric refers to the container resource utilization.
 	// Please check out the document for more detail: https://github.com/mercari/tortoise/blob/master/docs/horizontal.md#supported-metrics-in-hpa
 	//
-	// You can specify either of existing HPA or non existing HPA.
-	// If non existing HPA is specified, tortoise will create HPA with the given name.
-	// The default value is "{Tortoise name} + -hpa".
+	// You can specify either of existing HPA only.
+	// This is an optional field, and if you don't specify this field, tortoise will create a new default HPA named `tortoise-hpa-{tortoise name}`.
 	// +optional
 	HorizontalPodAutoscalerName *string `json:"horizontalPodAutoscalerName,omitempty" protobuf:"bytes,2,opt,name=horizontalPodAutoscalerName"`
 }

--- a/config/crd/bases/autoscaling.mercari.com_tortoises.yaml
+++ b/config/crd/bases/autoscaling.mercari.com_tortoises.yaml
@@ -99,9 +99,9 @@ spec:
                       metric or the external metric refers to the container resource
                       utilization. Please check out the document for more detail:
                       https://github.com/mercari/tortoise/blob/master/docs/horizontal.md#supported-metrics-in-hpa
-                      \n You can specify either of existing HPA or non existing HPA.
-                      If non existing HPA is specified, tortoise will create HPA with
-                      the given name. The default value is \"{Tortoise name} + -hpa\"."
+                      \n You can specify either of existing HPA only. This is an optional
+                      field, and if you don't specify this field, tortoise will create
+                      a new default HPA named `tortoise-hpa-{tortoise name}`."
                     type: string
                 required:
                 - deploymentName

--- a/controllers/tortoise_controller.go
+++ b/controllers/tortoise_controller.go
@@ -171,7 +171,7 @@ func (r *TortoiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 func (r *TortoiseReconciler) initializeVPAAndHPA(ctx context.Context, tortoise *autoscalingv1alpha1.Tortoise, dm *v1.Deployment, now time.Time) error {
 	// need to initialize HPA and VPA.
-	err := r.HpaService.InitializeHPA(ctx, tortoise, dm)
+	tortoise, err := r.HpaService.InitializeHPA(ctx, tortoise, dm)
 	if err != nil {
 		return err
 	}

--- a/controllers/tortoise_controller.go
+++ b/controllers/tortoise_controller.go
@@ -170,20 +170,10 @@ func (r *TortoiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 }
 
 func (r *TortoiseReconciler) initializeVPAAndHPA(ctx context.Context, tortoise *autoscalingv1alpha1.Tortoise, dm *v1.Deployment, now time.Time) error {
-	var err error
 	// need to initialize HPA and VPA.
-	if tortoise.Spec.TargetRefs.HorizontalPodAutoscalerName == nil {
-		// create HPA
-		_, tortoise, err = r.HpaService.CreateHPA(ctx, tortoise, dm)
-		if err != nil {
-			return err
-		}
-	} else {
-		// update the existing HPA that the user set on tortoise.
-		err = r.HpaService.GiveAnnotationsOnHPA(ctx, tortoise)
-		if err != nil {
-			return err
-		}
+	err := r.HpaService.InitializeHPA(ctx, tortoise, dm)
+	if err != nil {
+		return err
 	}
 
 	_, tortoise, err = r.VpaService.CreateTortoiseMonitorVPA(ctx, tortoise)

--- a/controllers/tortoise_controller_test.go
+++ b/controllers/tortoise_controller_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Test TortoiseController", func() {
 		err = deleteObj(ctx, &autoscalingv1.VerticalPodAutoscaler{}, "tortoise-monitor-mercari")
 		Expect(err).ShouldNot(HaveOccurred())
 
-		err = deleteObj(ctx, &v2.HorizontalPodAutoscaler{}, "hpa")
+		err = deleteObj(ctx, &v2.HorizontalPodAutoscaler{}, "tortoise-hpa-mercari")
 		Expect(err).ShouldNot(HaveOccurred())
 	}
 
@@ -106,8 +106,7 @@ var _ = Describe("Test TortoiseController", func() {
 						SetName("mercari").
 						SetNamespace("default").
 						SetTargetRefs(v1alpha1.TargetRefs{
-							DeploymentName:              "mercari-app",
-							HorizontalPodAutoscalerName: pointer.String("hpa"),
+							DeploymentName: "mercari-app",
 						}).
 						AddResourcePolicy(v1alpha1.ContainerResourcePolicy{
 							ContainerName: "app",
@@ -211,8 +210,7 @@ var _ = Describe("Test TortoiseController", func() {
 					SetName("mercari").
 					SetNamespace("default").
 					SetTargetRefs(v1alpha1.TargetRefs{
-						DeploymentName:              "mercari-app",
-						HorizontalPodAutoscalerName: pointer.String("hpa"),
+						DeploymentName: "mercari-app",
 					}).
 					AddResourcePolicy(v1alpha1.ContainerResourcePolicy{
 						ContainerName: "app",
@@ -223,7 +221,7 @@ var _ = Describe("Test TortoiseController", func() {
 					}).
 					SetTortoisePhase(v1alpha1.TortoisePhaseWorking).
 					SetTargetsStatus(v1alpha1.TargetsStatus{
-						HorizontalPodAutoscaler: "hpa",
+						HorizontalPodAutoscaler: "tortoise-hpa-mercari",
 						VerticalPodAutoscalers: []v1alpha1.TargetStatusVerticalPodAutoscaler{
 							{Name: "tortoise-updater-mercari", Role: "Updater"},
 							{Name: "tortoise-monitor-mercari", Role: "Monitor"},
@@ -302,7 +300,7 @@ var _ = Describe("Test TortoiseController", func() {
 				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "mercari"}, gotTortoise)
 				g.Expect(err).ShouldNot(HaveOccurred())
 				gotHPA := &v2.HorizontalPodAutoscaler{}
-				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "hpa"}, gotHPA)
+				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "tortoise-hpa-mercari"}, gotHPA)
 				g.Expect(err).ShouldNot(HaveOccurred())
 				gotUpdaterVPA := &autoscalingv1.VerticalPodAutoscaler{}
 				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "tortoise-updater-mercari"}, gotUpdaterVPA)
@@ -329,8 +327,7 @@ var _ = Describe("Test TortoiseController", func() {
 						SetNamespace("default").
 						SetUpdateMode(v1alpha1.UpdateModeOff).
 						SetTargetRefs(v1alpha1.TargetRefs{
-							DeploymentName:              "mercari-app",
-							HorizontalPodAutoscalerName: pointer.String("hpa"),
+							DeploymentName: "mercari-app",
 						}).
 						AddResourcePolicy(v1alpha1.ContainerResourcePolicy{
 							ContainerName: "app",
@@ -407,8 +404,7 @@ var _ = Describe("Test TortoiseController", func() {
 					SetNamespace("default").
 					SetUpdateMode(v1alpha1.UpdateModeOff).
 					SetTargetRefs(v1alpha1.TargetRefs{
-						DeploymentName:              "mercari-app",
-						HorizontalPodAutoscalerName: pointer.String("hpa"),
+						DeploymentName: "mercari-app",
 					}).
 					AddResourcePolicy(v1alpha1.ContainerResourcePolicy{
 						ContainerName: "app",
@@ -419,7 +415,7 @@ var _ = Describe("Test TortoiseController", func() {
 					}).
 					SetTortoisePhase(v1alpha1.TortoisePhaseWorking).
 					SetTargetsStatus(v1alpha1.TargetsStatus{
-						HorizontalPodAutoscaler: "hpa",
+						HorizontalPodAutoscaler: "tortoise-hpa-mercari",
 						VerticalPodAutoscalers: []v1alpha1.TargetStatusVerticalPodAutoscaler{
 							{Name: "tortoise-updater-mercari", Role: "Updater"},
 							{Name: "tortoise-monitor-mercari", Role: "Monitor"},
@@ -498,7 +494,7 @@ var _ = Describe("Test TortoiseController", func() {
 				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "mercari"}, gotTortoise)
 				g.Expect(err).ShouldNot(HaveOccurred())
 				gotHPA := &v2.HorizontalPodAutoscaler{}
-				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "hpa"}, gotHPA)
+				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "tortoise-hpa-mercari"}, gotHPA)
 				g.Expect(err).ShouldNot(HaveOccurred())
 				gotUpdaterVPA := &autoscalingv1.VerticalPodAutoscaler{}
 				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "tortoise-updater-mercari"}, gotUpdaterVPA)
@@ -522,8 +518,7 @@ var _ = Describe("Test TortoiseController", func() {
 						SetName("mercari").
 						SetNamespace("default").
 						SetTargetRefs(v1alpha1.TargetRefs{
-							DeploymentName:              "mercari-app",
-							HorizontalPodAutoscalerName: pointer.String("hpa"),
+							DeploymentName: "mercari-app",
 						}).
 						SetUpdateMode(v1alpha1.UpdateModeEmergency).
 						AddResourcePolicy(v1alpha1.ContainerResourcePolicy{
@@ -628,8 +623,7 @@ var _ = Describe("Test TortoiseController", func() {
 					SetName("mercari").
 					SetNamespace("default").
 					SetTargetRefs(v1alpha1.TargetRefs{
-						DeploymentName:              "mercari-app",
-						HorizontalPodAutoscalerName: pointer.String("hpa"),
+						DeploymentName: "mercari-app",
 					}).
 					SetUpdateMode(v1alpha1.UpdateModeEmergency).
 					AddResourcePolicy(v1alpha1.ContainerResourcePolicy{
@@ -641,7 +635,7 @@ var _ = Describe("Test TortoiseController", func() {
 					}).
 					SetTortoisePhase(v1alpha1.TortoisePhaseEmergency).
 					SetTargetsStatus(v1alpha1.TargetsStatus{
-						HorizontalPodAutoscaler: "hpa",
+						HorizontalPodAutoscaler: "tortoise-hpa-mercari",
 						VerticalPodAutoscalers: []v1alpha1.TargetStatusVerticalPodAutoscaler{
 							{Name: "tortoise-updater-mercari", Role: "Updater"},
 							{Name: "tortoise-monitor-mercari", Role: "Monitor"},
@@ -720,7 +714,7 @@ var _ = Describe("Test TortoiseController", func() {
 				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "mercari"}, gotTortoise)
 				g.Expect(err).ShouldNot(HaveOccurred())
 				gotHPA := &v2.HorizontalPodAutoscaler{}
-				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "hpa"}, gotHPA)
+				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "tortoise-hpa-mercari"}, gotHPA)
 				g.Expect(err).ShouldNot(HaveOccurred())
 				gotUpdaterVPA := &autoscalingv1.VerticalPodAutoscaler{}
 				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "tortoise-updater-mercari"}, gotUpdaterVPA)
@@ -746,8 +740,7 @@ var _ = Describe("Test TortoiseController", func() {
 						SetName("mercari").
 						SetNamespace("default").
 						SetTargetRefs(v1alpha1.TargetRefs{
-							DeploymentName:              "mercari-app",
-							HorizontalPodAutoscalerName: pointer.String("hpa"),
+							DeploymentName: "mercari-app",
 						}).
 						AddResourcePolicy(v1alpha1.ContainerResourcePolicy{
 							ContainerName: "app",
@@ -897,8 +890,7 @@ var _ = Describe("Test TortoiseController", func() {
 					SetName("mercari").
 					SetNamespace("default").
 					SetTargetRefs(v1alpha1.TargetRefs{
-						DeploymentName:              "mercari-app",
-						HorizontalPodAutoscalerName: pointer.String("hpa"),
+						DeploymentName: "mercari-app",
 					}).
 					AddResourcePolicy(v1alpha1.ContainerResourcePolicy{
 						ContainerName: "app",
@@ -916,7 +908,7 @@ var _ = Describe("Test TortoiseController", func() {
 					}).
 					SetTortoisePhase(v1alpha1.TortoisePhaseWorking).
 					SetTargetsStatus(v1alpha1.TargetsStatus{
-						HorizontalPodAutoscaler: "hpa",
+						HorizontalPodAutoscaler: "tortoise-hpa-mercari",
 						VerticalPodAutoscalers: []v1alpha1.TargetStatusVerticalPodAutoscaler{
 							{Name: "tortoise-updater-mercari", Role: "Updater"},
 							{Name: "tortoise-monitor-mercari", Role: "Monitor"},
@@ -1028,7 +1020,7 @@ var _ = Describe("Test TortoiseController", func() {
 				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "mercari"}, gotTortoise)
 				g.Expect(err).ShouldNot(HaveOccurred())
 				gotHPA := &v2.HorizontalPodAutoscaler{}
-				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "hpa"}, gotHPA)
+				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "tortoise-hpa-mercari"}, gotHPA)
 				g.Expect(err).ShouldNot(HaveOccurred())
 				gotUpdaterVPA := &autoscalingv1.VerticalPodAutoscaler{}
 				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "tortoise-updater-mercari"}, gotUpdaterVPA)
@@ -1052,8 +1044,7 @@ var _ = Describe("Test TortoiseController", func() {
 						SetName("mercari").
 						SetNamespace("default").
 						SetTargetRefs(v1alpha1.TargetRefs{
-							DeploymentName:              "mercari-app",
-							HorizontalPodAutoscalerName: pointer.String("hpa"),
+							DeploymentName: "mercari-app",
 						}).
 						AddResourcePolicy(v1alpha1.ContainerResourcePolicy{
 							ContainerName: "app",
@@ -1204,8 +1195,7 @@ var _ = Describe("Test TortoiseController", func() {
 					SetName("mercari").
 					SetNamespace("default").
 					SetTargetRefs(v1alpha1.TargetRefs{
-						DeploymentName:              "mercari-app",
-						HorizontalPodAutoscalerName: pointer.String("hpa"),
+						DeploymentName: "mercari-app",
 					}).
 					AddResourcePolicy(v1alpha1.ContainerResourcePolicy{
 						ContainerName: "app",
@@ -1224,7 +1214,7 @@ var _ = Describe("Test TortoiseController", func() {
 					SetUpdateMode(v1alpha1.UpdateModeEmergency).
 					SetTortoisePhase(v1alpha1.TortoisePhaseEmergency).
 					SetTargetsStatus(v1alpha1.TargetsStatus{
-						HorizontalPodAutoscaler: "hpa",
+						HorizontalPodAutoscaler: "tortoise-hpa-mercari",
 						VerticalPodAutoscalers: []v1alpha1.TargetStatusVerticalPodAutoscaler{
 							{Name: "tortoise-updater-mercari", Role: "Updater"},
 							{Name: "tortoise-monitor-mercari", Role: "Monitor"},
@@ -1336,7 +1326,7 @@ var _ = Describe("Test TortoiseController", func() {
 				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "mercari"}, gotTortoise)
 				g.Expect(err).ShouldNot(HaveOccurred())
 				gotHPA := &v2.HorizontalPodAutoscaler{}
-				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "hpa"}, gotHPA)
+				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "tortoise-hpa-mercari"}, gotHPA)
 				g.Expect(err).ShouldNot(HaveOccurred())
 				gotUpdaterVPA := &autoscalingv1.VerticalPodAutoscaler{}
 				err = k8sClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "tortoise-updater-mercari"}, gotUpdaterVPA)

--- a/pkg/hpa/service_test.go
+++ b/pkg/hpa/service_test.go
@@ -7,8 +7,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	autoscalingv1alpha1 "github.com/mercari/tortoise/api/v1alpha1"
-	"github.com/mercari/tortoise/pkg/annotation"
 	appv1 "k8s.io/api/apps/v1"
 	v2 "k8s.io/api/autoscaling/v2"
 	v1 "k8s.io/api/core/v1"
@@ -17,6 +15,9 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	autoscalingv1alpha1 "github.com/mercari/tortoise/api/v1alpha1"
+	"github.com/mercari/tortoise/pkg/annotation"
 )
 
 func TestClient_UpdateHPAFromTortoiseRecommendation(t *testing.T) {
@@ -40,12 +41,10 @@ func TestClient_UpdateHPAFromTortoiseRecommendation(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				tortoise: &autoscalingv1alpha1.Tortoise{
-					Spec: autoscalingv1alpha1.TortoiseSpec{
-						TargetRefs: autoscalingv1alpha1.TargetRefs{
-							HorizontalPodAutoscalerName: pointer.String("hpa"),
-						},
-					},
 					Status: autoscalingv1alpha1.TortoiseStatus{
+						Targets: autoscalingv1alpha1.TargetsStatus{
+							HorizontalPodAutoscaler: "hpa",
+						},
 						Recommendations: autoscalingv1alpha1.Recommendations{
 							Horizontal: &autoscalingv1alpha1.HorizontalRecommendations{
 								TargetUtilizations: []autoscalingv1alpha1.HPATargetUtilizationRecommendationPerContainer{
@@ -175,12 +174,10 @@ func TestClient_UpdateHPAFromTortoiseRecommendation(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				tortoise: &autoscalingv1alpha1.Tortoise{
-					Spec: autoscalingv1alpha1.TortoiseSpec{
-						TargetRefs: autoscalingv1alpha1.TargetRefs{
-							HorizontalPodAutoscalerName: pointer.String("hpa"),
-						},
-					},
 					Status: autoscalingv1alpha1.TortoiseStatus{
+						Targets: autoscalingv1alpha1.TargetsStatus{
+							HorizontalPodAutoscaler: "hpa",
+						},
 						Recommendations: autoscalingv1alpha1.Recommendations{
 							Horizontal: &autoscalingv1alpha1.HorizontalRecommendations{
 								TargetUtilizations: []autoscalingv1alpha1.HPATargetUtilizationRecommendationPerContainer{
@@ -308,11 +305,11 @@ func TestClient_UpdateHPAFromTortoiseRecommendation(t *testing.T) {
 				tortoise: &autoscalingv1alpha1.Tortoise{
 					Spec: autoscalingv1alpha1.TortoiseSpec{
 						UpdateMode: autoscalingv1alpha1.UpdateModeOff,
-						TargetRefs: autoscalingv1alpha1.TargetRefs{
-							HorizontalPodAutoscalerName: pointer.String("hpa"),
-						},
 					},
 					Status: autoscalingv1alpha1.TortoiseStatus{
+						Targets: autoscalingv1alpha1.TargetsStatus{
+							HorizontalPodAutoscaler: "hpa",
+						},
 						Recommendations: autoscalingv1alpha1.Recommendations{
 							Horizontal: &autoscalingv1alpha1.HorizontalRecommendations{
 								TargetUtilizations: []autoscalingv1alpha1.HPATargetUtilizationRecommendationPerContainer{
@@ -438,12 +435,10 @@ func TestClient_UpdateHPAFromTortoiseRecommendation(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				tortoise: &autoscalingv1alpha1.Tortoise{
-					Spec: autoscalingv1alpha1.TortoiseSpec{
-						TargetRefs: autoscalingv1alpha1.TargetRefs{
-							HorizontalPodAutoscalerName: pointer.String("hpa"),
-						},
-					},
 					Status: autoscalingv1alpha1.TortoiseStatus{
+						Targets: autoscalingv1alpha1.TargetsStatus{
+							HorizontalPodAutoscaler: "hpa",
+						},
 						TortoisePhase: autoscalingv1alpha1.TortoisePhaseEmergency,
 						Recommendations: autoscalingv1alpha1.Recommendations{
 							Horizontal: &autoscalingv1alpha1.HorizontalRecommendations{
@@ -570,12 +565,10 @@ func TestClient_UpdateHPAFromTortoiseRecommendation(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				tortoise: &autoscalingv1alpha1.Tortoise{
-					Spec: autoscalingv1alpha1.TortoiseSpec{
-						TargetRefs: autoscalingv1alpha1.TargetRefs{
-							HorizontalPodAutoscalerName: pointer.String("hpa"),
-						},
-					},
 					Status: autoscalingv1alpha1.TortoiseStatus{
+						Targets: autoscalingv1alpha1.TargetsStatus{
+							HorizontalPodAutoscaler: "hpa",
+						},
 						TortoisePhase: autoscalingv1alpha1.TortoisePhaseBackToNormal,
 						Recommendations: autoscalingv1alpha1.Recommendations{
 							Horizontal: &autoscalingv1alpha1.HorizontalRecommendations{
@@ -702,12 +695,10 @@ func TestClient_UpdateHPAFromTortoiseRecommendation(t *testing.T) {
 			args: args{
 				ctx: context.Background(),
 				tortoise: &autoscalingv1alpha1.Tortoise{
-					Spec: autoscalingv1alpha1.TortoiseSpec{
-						TargetRefs: autoscalingv1alpha1.TargetRefs{
-							HorizontalPodAutoscalerName: pointer.String("hpa"),
-						},
-					},
 					Status: autoscalingv1alpha1.TortoiseStatus{
+						Targets: autoscalingv1alpha1.TargetsStatus{
+							HorizontalPodAutoscaler: "hpa",
+						},
 						TortoisePhase: autoscalingv1alpha1.TortoisePhaseBackToNormal,
 						Recommendations: autoscalingv1alpha1.Recommendations{
 							Horizontal: &autoscalingv1alpha1.HorizontalRecommendations{
@@ -828,12 +819,10 @@ func TestClient_UpdateHPAFromTortoiseRecommendation(t *testing.T) {
 				},
 			},
 			wantTortoise: &autoscalingv1alpha1.Tortoise{
-				Spec: autoscalingv1alpha1.TortoiseSpec{
-					TargetRefs: autoscalingv1alpha1.TargetRefs{
-						HorizontalPodAutoscalerName: pointer.String("hpa"),
-					},
-				},
 				Status: autoscalingv1alpha1.TortoiseStatus{
+					Targets: autoscalingv1alpha1.TargetsStatus{
+						HorizontalPodAutoscaler: "hpa",
+					},
 					TortoisePhase: autoscalingv1alpha1.TortoisePhaseWorking,
 					Recommendations: autoscalingv1alpha1.Recommendations{
 						Horizontal: &autoscalingv1alpha1.HorizontalRecommendations{
@@ -923,8 +912,7 @@ func TestService_InitializeHPA(t *testing.T) {
 					},
 					Spec: autoscalingv1alpha1.TortoiseSpec{
 						TargetRefs: autoscalingv1alpha1.TargetRefs{
-							HorizontalPodAutoscalerName: pointer.String("hpa"),
-							DeploymentName:              "deployment",
+							DeploymentName: "deployment",
 						},
 					},
 				},
@@ -952,7 +940,7 @@ func TestService_InitializeHPA(t *testing.T) {
 			},
 			afterHPA: &v2.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "hpa",
+					Name:      "tortoise-hpa-tortoise",
 					Namespace: "default",
 					Annotations: map[string]string{
 						annotation.TortoiseNameAnnotation: "tortoise",
@@ -1081,11 +1069,12 @@ func TestService_InitializeHPA(t *testing.T) {
 			if tt.initialHPA != nil {
 				c = New(fake.NewClientBuilder().WithRuntimeObjects(tt.initialHPA).Build(), 0.95, 90)
 			}
-			if err := c.InitializeHPA(context.Background(), tt.args.tortoise, tt.args.dm); (err != nil) != tt.wantErr {
+			_, err := c.InitializeHPA(context.Background(), tt.args.tortoise, tt.args.dm)
+			if (err != nil) != tt.wantErr {
 				t.Errorf("Service.InitializeHPA() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			hpa := &v2.HorizontalPodAutoscaler{}
-			err := c.c.Get(context.Background(), client.ObjectKey{Name: tt.afterHPA.Name, Namespace: tt.afterHPA.Namespace}, hpa)
+			err = c.c.Get(context.Background(), client.ObjectKey{Name: tt.afterHPA.Name, Namespace: tt.afterHPA.Namespace}, hpa)
 			if err != nil {
 				t.Errorf("get hpa error = %v", err)
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/
-->

#### What this PR does / why we need it:

`tortoise.Spec.TargetRefs.HorizontalPodAutoscalerName` is set by the mutating webhook. So, it won't be nil basically.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
