### PR TITLE
cleanup HPAs and VPAs created by tortoise when deleting tortoises

### DIFF
--- a/api/v1alpha1/tortoise_types.go
+++ b/api/v1alpha1/tortoise_types.go
@@ -57,6 +57,14 @@ type TortoiseSpec struct {
 	// FeatureGates allows to list the alpha feature names.
 	// +optional
 	FeatureGates []string `json:"featureGates,omitempty" protobuf:"bytes,4,opt,name=featureGates"`
+	// DeletionPolicy is the policy how the controller deletes associated HPA and VPAs when tortoise is removed.
+	// If "DeleteAll", tortoise deletes all associated HPA and VPAs, created by tortoise. If the associated HPA is not created by tortoise,
+	// which is associated by spec.targetRefs.horizontalPodAutoscalerName, tortoise never delete the HPA.
+	// If "NoDelete", tortoise doesn't delete any associated HPA and VPAs.
+	//
+	// "DeleteAll" is the default value.
+	// +optional
+	DeletionPolicy DeletionPolicy `json:"deletionPolicy,omitempty" protobuf:"bytes,5,opt,name=deletionPolicy"`
 }
 
 type ContainerResourcePolicy struct {
@@ -81,6 +89,14 @@ type ContainerResourcePolicy struct {
 	// +optional
 	AutoscalingPolicy map[v1.ResourceName]AutoscalingType `json:"autoscalingPolicy,omitempty" protobuf:"bytes,3,opt,name=autoscalingPolicy"`
 }
+
+// +kubebuilder:validation:Enum=DeleteAll;NoDelete
+type DeletionPolicy string
+
+const (
+	DeletionPolicyDeleteAll DeletionPolicy = "DeleteAll"
+	DeletionPolicyNoDelete  DeletionPolicy = "NoDelete"
+)
 
 // +kubebuilder:validation:Enum=Off;Auto;Emergency
 type UpdateMode string

--- a/api/v1alpha1/tortoise_webhook.go
+++ b/api/v1alpha1/tortoise_webhook.go
@@ -74,6 +74,9 @@ func (r *Tortoise) Default() {
 	if r.Spec.UpdateMode == "" {
 		r.Spec.UpdateMode = UpdateModeOff
 	}
+	if r.Spec.DeletionPolicy == "" {
+		r.Spec.DeletionPolicy = DeletionPolicyDeleteAll
+	}
 
 	d, err := ClientService.GetDeploymentOnTortoise(context.Background(), r)
 	if err != nil {

--- a/config/crd/bases/autoscaling.mercari.com_tortoises.yaml
+++ b/config/crd/bases/autoscaling.mercari.com_tortoises.yaml
@@ -35,6 +35,18 @@ spec:
           spec:
             description: TortoiseSpec defines the desired state of Tortoise
             properties:
+              deletionPolicy:
+                description: "DeletionPolicy is the policy how the controller deletes
+                  associated HPA and VPAs when tortoise is removed. If \"DeleteAll\",
+                  tortoise deletes all associated HPA and VPAs, created by tortoise.
+                  If the associated HPA is not created by tortoise, which is associated
+                  by spec.targetRefs.horizontalPodAutoscalerName, tortoise never delete
+                  the HPA. If \"NoDelete\", tortoise doesn't delete any associated
+                  HPA and VPAs. \n \"DeleteAll\" is the default value."
+                enum:
+                - DeleteAll
+                - NoDelete
+                type: string
               featureGates:
                 description: FeatureGates allows to list the alpha feature names.
                 items:

--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -6,4 +6,8 @@ const (
 
 	// TortoiseNameAnnotation - VPA and HPA managed by tortoise have this label.
 	TortoiseNameAnnotation = "tortoises.autoscaling.mercari.com/tortoise-name"
+
+	// If this annotation is set to "true", it means that tortoise manages that resource,
+	// and will be removed when the tortoise is deleted.
+	ManagedByTortoiseAnnotation = "tortoise.autoscaling.mercari.com/managed-by-tortoise"
 )

--- a/pkg/hpa/service_test.go
+++ b/pkg/hpa/service_test.go
@@ -943,7 +943,8 @@ func TestService_InitializeHPA(t *testing.T) {
 					Name:      "tortoise-hpa-tortoise",
 					Namespace: "default",
 					Annotations: map[string]string{
-						annotation.TortoiseNameAnnotation: "tortoise",
+						annotation.TortoiseNameAnnotation:      "tortoise",
+						annotation.ManagedByTortoiseAnnotation: "true",
 					},
 				},
 				Spec: v2.HorizontalPodAutoscalerSpec{
@@ -1037,7 +1038,8 @@ func TestService_InitializeHPA(t *testing.T) {
 					Name:      "existing-hpa",
 					Namespace: "default",
 					Annotations: map[string]string{
-						annotation.TortoiseNameAnnotation: "tortoise",
+						annotation.TortoiseNameAnnotation:      "tortoise",
+						annotation.ManagedByTortoiseAnnotation: "true",
 					},
 				},
 				Spec: v2.HorizontalPodAutoscalerSpec{

--- a/pkg/utils/tortoise_builder.go
+++ b/pkg/utils/tortoise_builder.go
@@ -28,6 +28,10 @@ func (b *TortoiseBuilder) SetTargetRefs(targetRefs v1alpha1.TargetRefs) *Tortois
 	b.tortoise.Spec.TargetRefs = targetRefs
 	return b
 }
+func (b *TortoiseBuilder) SetDeletionPolicy(policy v1alpha1.DeletionPolicy) *TortoiseBuilder {
+	b.tortoise.Spec.DeletionPolicy = policy
+	return b
+}
 
 func (b *TortoiseBuilder) SetUpdateMode(updateMode v1alpha1.UpdateMode) *TortoiseBuilder {
 	b.tortoise.Spec.UpdateMode = updateMode


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/
-->

#### What this PR does / why we need it:


DeletionPolicy is the policy how the controller deletes associated HPA and VPAs when tortoise is removed.
If "DeleteAll", tortoise deletes all associated HPA and VPAs, created by tortoise. If the associated HPA is not created by tortoise,
which is associated by spec.targetRefs.horizontalPodAutoscalerName, tortoise never delete the HPA.
If "NoDelete", tortoise doesn't delete any associated HPA and VPAs.
	
"DeleteAll" is the default value.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #58

#### Special notes for your reviewer:
