### PR TITLE
fix: don't let maxReplicas go to below minReplicas

### DIFF
--- a/pkg/recommender/recommender.go
+++ b/pkg/recommender/recommender.go
@@ -207,7 +207,7 @@ func (s *Service) updateHPAMinMaxReplicasRecommendations(tortoise *v1alpha1.Tort
 		return tortoise, fmt.Errorf("update MinReplicas recommendation: %w", err)
 	}
 	tortoise.Status.Recommendations.Horizontal.MinReplicas = min
-	max, err := s.updateMaxMinReplicasRecommendation(int32(math.Ceil(currentReplicaNum*s.maxReplicasFactor)), tortoise.Status.Recommendations.Horizontal.MaxReplicas, now, 0)
+	max, err := s.updateMaxMinReplicasRecommendation(int32(math.Ceil(currentReplicaNum*s.maxReplicasFactor)), tortoise.Status.Recommendations.Horizontal.MaxReplicas, now, int32(float64(s.minimumMinReplicas)*s.maxReplicasFactor/s.minReplicasFactor))
 	if err != nil {
 		return tortoise, fmt.Errorf("update MaxReplicas recommendation: %w", err)
 	}

--- a/pkg/recommender/recommender_test.go
+++ b/pkg/recommender/recommender_test.go
@@ -496,7 +496,7 @@ func Test_updateHPAMinMaxReplicasRecommendations(t *testing.T) {
 				},
 				deployment: &v1.Deployment{
 					Status: v1.DeploymentStatus{
-						Replicas: 4,
+						Replicas: 10,
 					},
 				},
 				now: time.Date(2023, 3, 19, 0, 0, 0, 0, jst),
@@ -510,7 +510,7 @@ func Test_updateHPAMinMaxReplicasRecommendations(t *testing.T) {
 									From:      0,
 									To:        1,
 									UpdatedAt: metav1.NewTime(time.Date(2023, 3, 19, 0, 0, 0, 0, jst)),
-									Value:     3,
+									Value:     5,
 									WeekDay:   time.Sunday.String(),
 								},
 							},
@@ -519,7 +519,7 @@ func Test_updateHPAMinMaxReplicasRecommendations(t *testing.T) {
 									From:      0,
 									To:        1,
 									UpdatedAt: metav1.NewTime(time.Date(2023, 3, 19, 0, 0, 0, 0, jst)),
-									Value:     8,
+									Value:     20,
 									WeekDay:   time.Sunday.String(),
 								},
 							},
@@ -658,7 +658,71 @@ func Test_updateHPAMinMaxReplicasRecommendations(t *testing.T) {
 				},
 				deployment: &v1.Deployment{
 					Status: v1.DeploymentStatus{
-						Replicas: 4,
+						Replicas: 10,
+					},
+				},
+				now: time.Date(2023, 3, 19, 0, 0, 0, 0, jst),
+			},
+			want: &v1alpha1.Tortoise{
+				Status: v1alpha1.TortoiseStatus{
+					Recommendations: v1alpha1.Recommendations{
+						Horizontal: &v1alpha1.HorizontalRecommendations{
+							MinReplicas: []v1alpha1.ReplicasRecommendation{
+								{
+									From:      0,
+									To:        1,
+									UpdatedAt: metav1.NewTime(time.Date(2023, 3, 19, 0, 0, 0, 0, jst)),
+									Value:     5,
+									WeekDay:   time.Sunday.String(),
+								},
+							},
+							MaxReplicas: []v1alpha1.ReplicasRecommendation{
+								{
+									From:      0,
+									To:        1,
+									UpdatedAt: metav1.NewTime(time.Date(2023, 3, 19, 0, 0, 0, 0, jst)),
+									Value:     20,
+									WeekDay:   time.Sunday.String(),
+								},
+							},
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "minimum MinReplicas and minimum MaxReplicas",
+			args: args{
+				tortoise: &v1alpha1.Tortoise{
+					Status: v1alpha1.TortoiseStatus{
+						Recommendations: v1alpha1.Recommendations{
+							Horizontal: &v1alpha1.HorizontalRecommendations{
+								MinReplicas: []v1alpha1.ReplicasRecommendation{
+									{
+										From:      0,
+										To:        1,
+										UpdatedAt: metav1.NewTime(time.Date(2023, 3, 12, 0, 0, 0, 0, jst)),
+										Value:     3,
+										WeekDay:   time.Sunday.String(),
+									},
+								},
+								MaxReplicas: []v1alpha1.ReplicasRecommendation{
+									{
+										From:      0,
+										To:        1,
+										UpdatedAt: metav1.NewTime(time.Date(2023, 3, 12, 0, 0, 0, 0, jst)),
+										Value:     8,
+										WeekDay:   time.Sunday.String(),
+									},
+								},
+							},
+						},
+					},
+				},
+				deployment: &v1.Deployment{
+					Status: v1.DeploymentStatus{
+						Replicas: 1,
 					},
 				},
 				now: time.Date(2023, 3, 19, 0, 0, 0, 0, jst),
@@ -681,7 +745,7 @@ func Test_updateHPAMinMaxReplicasRecommendations(t *testing.T) {
 									From:      0,
 									To:        1,
 									UpdatedAt: metav1.NewTime(time.Date(2023, 3, 19, 0, 0, 0, 0, jst)),
-									Value:     8,
+									Value:     12,
 									WeekDay:   time.Sunday.String(),
 								},
 							},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/
-->

#### What this PR does / why we need it:

When it's dry-run mode, it can go below minimumMinReplicas. So, it's safer to protect maxReplicas don't go below MinReplicas.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
