### PR TITLE
fix: rename the metrics for proposed resource requests

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -21,10 +21,15 @@ var (
 		Help: "recommended hpa maxReplicas that tortoises propose",
 	}, []string{"tortoise_name", "namespace", "hpa_name"})
 
-	ProposedResourceRequest = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "proposed_resource_request",
+	ProposedCPURequest = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "proposed_cpu_request",
 		Help: "recommended resource request that tortoises propose",
-	}, []string{"tortoise_name", "namespace", "container_name", "resource_name"})
+	}, []string{"tortoise_name", "namespace", "container_name"})
+
+	ProposedMemoryRequest = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "proposed_memory_request",
+		Help: "recommended resource request that tortoises propose",
+	}, []string{"tortoise_name", "namespace", "container_name"})
 )
 
 func init() {
@@ -33,6 +38,7 @@ func init() {
 		ProposedHPATargetUtilization,
 		ProposedHPAMinReplicass,
 		ProposedHPAMaxReplicass,
-		ProposedResourceRequest,
+		ProposedCPURequest,
+		ProposedMemoryRequest,
 	)
 }

--- a/pkg/vpa/service.go
+++ b/pkg/vpa/service.go
@@ -208,7 +208,12 @@ func (c *Service) UpdateVPAFromTortoiseRecommendation(ctx context.Context, torto
 		for _, r := range tortoise.Status.Recommendations.Vertical.ContainerResourceRecommendation {
 			if !metricsRecorded {
 				for resourcename, value := range r.RecommendedResource {
-					metrics.ProposedResourceRequest.WithLabelValues(tortoise.Name, tortoise.Namespace, r.ContainerName, resourcename.String()).Set(float64(value.MilliValue()))
+					if resourcename == corev1.ResourceCPU {
+						metrics.ProposedCPURequest.WithLabelValues(tortoise.Name, tortoise.Namespace, r.ContainerName).Set(float64(value.MilliValue()))
+					}
+					if resourcename == corev1.ResourceMemory {
+						metrics.ProposedCPURequest.WithLabelValues(tortoise.Name, tortoise.Namespace, r.ContainerName).Set(float64(value.MilliValue()))
+					}
 				}
 				metricsRecorded = true
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/
-->

#### What this PR does / why we need it:

- delete `proposed_resource_request`
  - It contains both cpu and memory, which is hard to see.
- create `proposed_cpu_request` and `proposed_memory_request`

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
