### PR TITLE
parse flags before reading configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -79,17 +79,18 @@ func main() {
 	// Tortoise specific flags
 	var configPath string
 	flag.StringVar(&configPath, "config", "", "The path to the config file.")
-	config, err := config.ParseConfig(configPath)
-	if err != nil {
-		setupLog.Error(err, "failed to load config")
-		os.Exit(1)
-	}
 
 	opts := zap.Options{
 		Development: true,
 	}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	config, err := config.ParseConfig(configPath)
+	if err != nil {
+		setupLog.Error(err, "failed to load config")
+		os.Exit(1)
+	}
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 

--- a/pkg/config/testdata/config.yaml
+++ b/pkg/config/testdata/config.yaml
@@ -1,5 +1,5 @@
 RangeOfMinMaxReplicasRecommendationHours: 2
-MinMaxReplicasRecommendationType:                    "daily"
+MinMaxReplicasRecommendationType:         "daily"
 TTLHoursOfMinMaxReplicasRecommendation:   720
 MaxReplicasFactor:                        2.0
 MinReplicasFactor:                        0.5


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/
-->

#### What this PR does / why we need it:

ssia otherwise configPath passed to `config.ParseConfig` is always empty.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
