### PR TITLE
don't modify HPA in webhook when dryrun

### DIFF
--- a/api/autoscaling/v2/horizontalpodautoscaler_webhook.go
+++ b/api/autoscaling/v2/horizontalpodautoscaler_webhook.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	"github.com/mercari/tortoise/api/v1beta2"
 	"github.com/mercari/tortoise/pkg/annotation"
 	"github.com/mercari/tortoise/pkg/hpa"
 	"github.com/mercari/tortoise/pkg/tortoise"
@@ -77,6 +78,11 @@ func (h *HPAWebhook) Default(ctx context.Context, obj runtime.Object) error {
 
 	if t.Status.Targets.HorizontalPodAutoscaler != hpa.Name {
 		// not managed by tortoise
+		return nil
+	}
+
+	if t.Spec.UpdateMode == v1beta2.UpdateModeOff {
+		// DryRun, don't update HPA
 		return nil
 	}
 

--- a/api/autoscaling/v2/horizontalpodautoscaler_webhook_test.go
+++ b/api/autoscaling/v2/horizontalpodautoscaler_webhook_test.go
@@ -93,6 +93,9 @@ var _ = Describe("v2.HPA Webhook", func() {
 		It("HPA is mutated based on the recommendation", func() {
 			mutateTest(filepath.Join("testdata", "mutating", "mutate-by-recommendations", "before.yaml"), filepath.Join("testdata", "mutating", "mutate-by-recommendations", "after.yaml"), filepath.Join("testdata", "mutating", "mutate-by-recommendations", "tortoise.yaml"))
 		})
+		It("HPA is not mutated (dryrun)", func() {
+			mutateTest(filepath.Join("testdata", "mutating", "no-mutate-by-recommendations-when-dryrun", "before.yaml"), filepath.Join("testdata", "mutating", "no-mutate-by-recommendations-when-dryrun", "after.yaml"), filepath.Join("testdata", "mutating", "no-mutate-by-recommendations-when-dryrun", "tortoise.yaml"))
+		})
 		It("HPA is not mutated because of invalid annotation", func() {
 			mutateTest(filepath.Join("testdata", "mutating", "has-annotation-but-invalid1", "before.yaml"), filepath.Join("testdata", "mutating", "has-annotation-but-invalid1", "after.yaml"), filepath.Join("testdata", "mutating", "has-annotation-but-invalid1", "tortoise.yaml"))
 			mutateTest(filepath.Join("testdata", "mutating", "has-annotation-but-invalid2", "before.yaml"), filepath.Join("testdata", "mutating", "has-annotation-but-invalid2", "after.yaml"), filepath.Join("testdata", "mutating", "has-annotation-but-invalid2", "tortoise.yaml"))

--- a/api/autoscaling/v2/testdata/mutating/no-mutate-by-recommendations-when-dryrun/after.yaml
+++ b/api/autoscaling/v2/testdata/mutating/no-mutate-by-recommendations-when-dryrun/after.yaml
@@ -1,0 +1,29 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: sample
+  namespace: default
+  annotations:
+    tortoises.autoscaling.mercari.com/tortoise-name: tortoise-sample
+spec:
+  maxReplicas: 10
+  metrics:
+    - type: ContainerResource
+      containerResource:
+        name: cpu
+        container: nginx
+        target:
+          type: Utilization
+          averageUtilization: 60
+    - type: ContainerResource
+      containerResource:
+        name: cpu
+        container: istio-proxy
+        target:
+          type: Utilization
+          averageUtilization: 60
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: sample

--- a/api/autoscaling/v2/testdata/mutating/no-mutate-by-recommendations-when-dryrun/before.yaml
+++ b/api/autoscaling/v2/testdata/mutating/no-mutate-by-recommendations-when-dryrun/before.yaml
@@ -1,0 +1,29 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: sample
+  namespace: default
+  annotations:
+    tortoises.autoscaling.mercari.com/tortoise-name: tortoise-sample
+spec:
+  maxReplicas: 10
+  metrics:
+    - type: ContainerResource
+      containerResource:
+        name: cpu
+        container: nginx
+        target:
+          type: Utilization
+          averageUtilization: 60
+    - type: ContainerResource
+      containerResource:
+        name: cpu
+        container: istio-proxy
+        target:
+          type: Utilization
+          averageUtilization: 60
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: sample

--- a/api/autoscaling/v2/testdata/mutating/no-mutate-by-recommendations-when-dryrun/tortoise.yaml
+++ b/api/autoscaling/v2/testdata/mutating/no-mutate-by-recommendations-when-dryrun/tortoise.yaml
@@ -4,7 +4,7 @@ metadata:
   name: tortoise-sample
   namespace: default
 spec:
-  updateMode: "Auto"
+  updateMode: "Off"
   deletionPolicy: "DeleteAll"
   targetRefs:
     horizontalPodAutoscalerName: sample


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/
-->

#### What this PR does / why we need it:

It's a bug where HPA is modified in webhook even when tortoise is in dryrun.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
