### PR TITLE
fix: take the istio annotation from pod template

### DIFF
--- a/api/v1beta2/testdata/mutating/deployment.yaml
+++ b/api/v1beta2/testdata/mutating/deployment.yaml
@@ -3,8 +3,6 @@ kind: Deployment
 metadata:
   name: sample
   namespace: default
-  annotations:
-    sidecar.istio.io/inject: "true"
   labels:
     app: nginx
 spec:
@@ -14,6 +12,8 @@ spec:
       app: nginx
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: nginx
     spec:

--- a/api/v1beta2/testdata/validating/fail-with-istio/deployment.yaml
+++ b/api/v1beta2/testdata/validating/fail-with-istio/deployment.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: default
   labels:
     app: nginx
-  annotations:
-    sidecar.istio.io/inject: "true"
 spec:
   replicas: 3
   selector:
@@ -14,6 +12,8 @@ spec:
       app: nginx
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: nginx
     spec:

--- a/api/v1beta2/testdata/validating/success-with-istio/deployment.yaml
+++ b/api/v1beta2/testdata/validating/success-with-istio/deployment.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: default
   labels:
     app: nginx
-  annotations:
-    sidecar.istio.io/inject: "true"
 spec:
   replicas: 3
   selector:
@@ -14,6 +12,8 @@ spec:
       app: nginx
   template:
     metadata:
+      annotations:
+        sidecar.istio.io/inject: "true"
       labels:
         app: nginx
     spec:

--- a/api/v1beta2/tortoise_webhook.go
+++ b/api/v1beta2/tortoise_webhook.go
@@ -86,8 +86,8 @@ func (r *Tortoise) Default() {
 		}
 
 		containers := d.Spec.Template.Spec.DeepCopy().Containers
-		if d.Annotations != nil {
-			if v, ok := d.Annotations[annotation.IstioSidecarInjectionAnnotation]; ok && v == "true" {
+		if d.Spec.Template.Annotations != nil {
+			if v, ok := d.Spec.Template.Annotations[annotation.IstioSidecarInjectionAnnotation]; ok && v == "true" {
 				// If the deployment has the sidecar injection annotation, the Pods will have the sidecar container in addition.
 				containers = append(d.Spec.Template.Spec.Containers, v1.Container{
 					Name: "istio-proxy",
@@ -200,8 +200,8 @@ func (r *Tortoise) ValidateCreate() (admission.Warnings, error) {
 			containers.Insert(c.Name)
 		}
 
-		if d.Annotations != nil {
-			if v, ok := d.Annotations[annotation.IstioSidecarInjectionAnnotation]; ok && v == "true" {
+		if d.Spec.Template.Annotations != nil {
+			if v, ok := d.Spec.Template.Annotations[annotation.IstioSidecarInjectionAnnotation]; ok && v == "true" {
 				// If the deployment has the sidecar injection annotation, the Pods will have the sidecar container in addition.
 				containers.Insert("istio-proxy")
 			}

--- a/controllers/testdata/reconcile-for-the-istio-enabled-pod-working/before/deployment.yaml
+++ b/controllers/testdata/reconcile-for-the-istio-enabled-pod-working/before/deployment.yaml
@@ -1,10 +1,6 @@
 metadata:
   name: mercari-app
   namespace: default
-  annotations:
-    sidecar.istio.io/inject: "true"
-    sidecar.istio.io/proxyCPU: "4"
-    sidecar.istio.io/proxyMemory: "4Gi"
 spec:
   selector:
     matchLabels:
@@ -12,7 +8,10 @@ spec:
   strategy: {}
   template:
     metadata:
-      creationTimestamp: null
+      annotations:
+        sidecar.istio.io/inject: "true"
+        sidecar.istio.io/proxyCPU: "4"
+        sidecar.istio.io/proxyMemory: "4Gi"
       labels:
         app: mercari
     spec:

--- a/controllers/tortoise_controller.go
+++ b/controllers/tortoise_controller.go
@@ -156,12 +156,12 @@ func (r *TortoiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_
 			tortoise.Status.Recommendations.Vertical.ContainerResourceRecommendation = append(tortoise.Status.Recommendations.Vertical.ContainerResourceRecommendation, rcr)
 		}
 
-		if dm.Annotations != nil {
-			if v, ok := dm.Annotations[annotation.IstioSidecarInjectionAnnotation]; ok && v == "true" {
+		if dm.Spec.Template.Annotations != nil {
+			if v, ok := dm.Spec.Template.Annotations[annotation.IstioSidecarInjectionAnnotation]; ok && v == "true" {
 				// Istio sidecar injection is enabled.
 				// Because the istio container spec is not in the deployment spec, we need to get it from the deployment's annotation.
 
-				cpuReq, ok := dm.Annotations[annotation.IstioSidecarProxyCPUAnnotation]
+				cpuReq, ok := dm.Spec.Template.Annotations[annotation.IstioSidecarProxyCPUAnnotation]
 				if !ok {
 					cpuReq = r.IstioSidecarProxyDefaultCPU
 				}
@@ -170,7 +170,7 @@ func (r *TortoiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_
 					return ctrl.Result{}, fmt.Errorf("parse CPU request of istio sidecar: %w", err)
 				}
 
-				memoryReq, ok := dm.Annotations[annotation.IstioSidecarProxyMemoryAnnotation]
+				memoryReq, ok := dm.Spec.Template.Annotations[annotation.IstioSidecarProxyMemoryAnnotation]
 				if !ok {
 					memoryReq = r.IstioSidecarProxyDefaultMemory
 				}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/
-->

#### What this PR does / why we need it:

Currently, we take it from the deployment's annotation. But, the Pod template's annotation is the right place.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
