### PR TITLE
support tortoise_number metric

### DIFF
--- a/controllers/tortoise_controller.go
+++ b/controllers/tortoise_controller.go
@@ -43,6 +43,7 @@ import (
 	"github.com/mercari/tortoise/pkg/annotation"
 	"github.com/mercari/tortoise/pkg/deployment"
 	"github.com/mercari/tortoise/pkg/hpa"
+	"github.com/mercari/tortoise/pkg/metrics"
 	"github.com/mercari/tortoise/pkg/recommender"
 	"github.com/mercari/tortoise/pkg/tortoise"
 	"github.com/mercari/tortoise/pkg/vpa"
@@ -103,8 +104,12 @@ func (r *TortoiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_
 		if err := r.TortoiseService.RemoveFinalizer(ctx, tortoise); err != nil {
 			return ctrl.Result{}, fmt.Errorf("remove finalizer: %w", err)
 		}
+
+		metrics.RecordTortoise(tortoise, true)
 		return ctrl.Result{RequeueAfter: r.Interval}, nil
 	}
+
+	metrics.RecordTortoise(tortoise, false)
 
 	defer func() {
 		if tortoise == nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/
-->

#### What this PR does / why we need it:

Support `tortoise_number` to see the number of tortoise in the cluster.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #62

#### Special notes for your reviewer:
