### PR TITLE
re-record tortoise metrics when phase or mode is changed

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -3,8 +3,6 @@ package metrics
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
-
-	"github.com/mercari/tortoise/api/v1beta3"
 )
 
 var (
@@ -79,19 +77,4 @@ func init() {
 		ProposedMemoryRequest,
 		TortoiseNumber,
 	)
-}
-
-func RecordTortoise(t *v1beta3.Tortoise, deleted bool) {
-	value := 1.0
-	if deleted {
-		value = 0
-	}
-	TortoiseNumber.WithLabelValues(
-		t.Name,
-		t.Namespace,
-		t.Spec.TargetRefs.ScaleTargetRef.Name,
-		t.Spec.TargetRefs.ScaleTargetRef.Kind,
-		string(t.Spec.UpdateMode),
-		string(t.Status.TortoisePhase),
-	).Set(value)
 }

--- a/pkg/metrics/tortoisenumber.go
+++ b/pkg/metrics/tortoisenumber.go
@@ -1,0 +1,25 @@
+package metrics
+
+import (
+	"github.com/mercari/tortoise/api/v1beta3"
+)
+
+func RecordTortoise(t *v1beta3.Tortoise, deleted bool) {
+	value := 1.0
+	if deleted {
+		value = 0
+	}
+	TortoiseNumber.WithLabelValues(
+		t.Name,
+		t.Namespace,
+		t.Spec.TargetRefs.ScaleTargetRef.Name,
+		t.Spec.TargetRefs.ScaleTargetRef.Kind,
+		string(t.Spec.UpdateMode),
+		string(t.Status.TortoisePhase),
+	).Set(value)
+}
+
+func ShouldRerecordTortoise(old, new *v1beta3.Tortoise) bool {
+	return old.Status.TortoisePhase != new.Status.TortoisePhase ||
+		old.Spec.UpdateMode != new.Spec.UpdateMode
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/
-->

#### What this PR does / why we need it:

re-record tortoise metrics when phase or mode is changed. Currently, the same tortoise could get duplicatedly recorded when they're changed.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
