### PR TITLE
restrict when tortoise can move to emergency mode

### DIFF
--- a/docs/emergency.md
+++ b/docs/emergency.md
@@ -9,6 +9,26 @@ Autoscalers on tortoise are configured based on the historical resource usage.
 If the workloads need to get scaled up in an unusual case (like unusual traffic increase etc),
 you can turn on the emergency mode by setting `Emergency` on `.spec.UpdateMode` in Tortoise.
 
+Note that Emergency mode is only available when your tortoise is `Working` or `PartlyWorking` AND has, at least, one Horizontal autoscaling policy.
+You can check via `.status.tortoisePhase` and `.status.autoscalingPolicy` field:
+
+```yaml
+$ kubectl get tortoise your-tortoise -n your-namespace 
+
+...
+status:
+  tortoisePhase: Working
+  autoscalingPolicy:
+  - containerName: application
+    policy:
+      cpu: Horizontal
+      memory: Vertical
+  - containerName: istio-proxy
+    policy:
+      cpu: Vertical
+      memory: Vertical
+```
+
 ### How emergency mode works
 
 When emergency mode is enabled, tortoise increases the `minReplicas` of HPA to the same value as `maxReplicas`.

--- a/pkg/event/event.go
+++ b/pkg/event/event.go
@@ -9,8 +9,9 @@ const (
 
 	RecommendationUpdated = "RecommendationUpdated"
 
-	Initialized   = "Initialized"
-	Working       = "Working"
-	PartlyWorking = "PartlyWorking"
-	Emergency     = "Emergency"
+	Initialized          = "Initialized"
+	Working              = "Working"
+	PartlyWorking        = "PartlyWorking"
+	EmergencyModeEnabled = "EmergencyModeEnabled"
+	EmergencyModeFailed  = "EmergencyModeFailed"
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/
-->

#### What this PR does / why we need it:

restrict when tortoise can move to emergency mode
- When phase is not TortoisePhasePartlyWorking or TortoisePhaseWorking, tortoise cannot move to emergency
- When tortoise doesn't have any horizontal, tortoise cannot move to emergency.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
