### PR TITLE
skip adding ContainerResourcePolicy to VPA when MinAllocatedResources is nil

### DIFF
--- a/pkg/vpa/service.go
+++ b/pkg/vpa/service.go
@@ -129,6 +129,9 @@ func (c *Service) CreateTortoiseUpdaterVPA(ctx context.Context, tortoise *autosc
 	}
 	crp := make([]v1.ContainerResourcePolicy, 0, len(tortoise.Spec.ResourcePolicy))
 	for _, c := range tortoise.Spec.ResourcePolicy {
+		if c.MinAllocatedResources == nil {
+			continue
+		}
 		crp = append(crp, v1.ContainerResourcePolicy{
 			ContainerName: c.ContainerName,
 			MinAllowed:    c.MinAllocatedResources,
@@ -175,6 +178,9 @@ func (c *Service) CreateTortoiseMonitorVPA(ctx context.Context, tortoise *autosc
 	}
 	crp := make([]v1.ContainerResourcePolicy, 0, len(tortoise.Spec.ResourcePolicy))
 	for _, c := range tortoise.Spec.ResourcePolicy {
+		if c.MinAllocatedResources == nil {
+			continue
+		}
 		crp = append(crp, v1.ContainerResourcePolicy{
 			ContainerName: c.ContainerName,
 			MinAllowed:    c.MinAllocatedResources,


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/
-->

#### What this PR does / why we need it:

skip adding ContainerResourcePolicy to VPA when MinAllocatedResources is nil

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
