### PR TITLE
don't scale down if we scale the deployment recently

### DIFF
--- a/controllers/testdata/mutable-autoscalingpolicy-add-another-horizontal/after/vpa-Updater.yaml
+++ b/controllers/testdata/mutable-autoscalingpolicy-add-another-horizontal/after/vpa-Updater.yaml
@@ -18,6 +18,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/mutable-autoscalingpolicy-no-hpa-and-add-horizontal/after/vpa-Updater.yaml
+++ b/controllers/testdata/mutable-autoscalingpolicy-no-hpa-and-add-horizontal/after/vpa-Updater.yaml
@@ -18,6 +18,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/mutable-autoscalingpolicy-remove-horizontal/after/vpa-Updater.yaml
+++ b/controllers/testdata/mutable-autoscalingpolicy-remove-horizontal/after/vpa-Updater.yaml
@@ -18,6 +18,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/reconcile-for-the-istio-enabled-pod-working/after/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-istio-enabled-pod-working/after/vpa-Updater.yaml
@@ -18,6 +18,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/reconcile-for-the-multiple-containers-pod-all-off/after/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-multiple-containers-pod-all-off/after/vpa-Updater.yaml
@@ -18,6 +18,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/reconcile-for-the-multiple-containers-pod-all-vertical/after/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-multiple-containers-pod-all-vertical/after/vpa-Updater.yaml
@@ -18,6 +18,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/reconcile-for-the-multiple-containers-pod-during-emergency/after/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-multiple-containers-pod-during-emergency/after/vpa-Updater.yaml
@@ -18,6 +18,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/reconcile-for-the-multiple-containers-pod-emergency-started/after/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-multiple-containers-pod-emergency-started/after/vpa-Updater.yaml
@@ -18,6 +18,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/reconcile-for-the-multiple-containers-pod-one-off/after/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-multiple-containers-pod-one-off/after/vpa-Updater.yaml
@@ -18,6 +18,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/reconcile-for-the-multiple-containers-pod-working/after/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-multiple-containers-pod-working/after/vpa-Updater.yaml
@@ -18,6 +18,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/reconcile-for-the-single-container-pod-backtonormal/after/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-backtonormal/after/vpa-Updater.yaml
@@ -17,6 +17,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/reconcile-for-the-single-container-pod-dryrun/after/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-dryrun/after/vpa-Updater.yaml
@@ -16,5 +16,3 @@ spec:
     name: mercari-app
   updatePolicy:
     updateMode: Initial
-status: 
-  recommendation: {}

--- a/controllers/testdata/reconcile-for-the-single-container-pod-during-emergency/after/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-during-emergency/after/vpa-Updater.yaml
@@ -17,6 +17,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/reconcile-for-the-single-container-pod-during-emergency/before/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-during-emergency/before/vpa-Updater.yaml
@@ -17,6 +17,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/reconcile-for-the-single-container-pod-emergency-started/after/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-emergency-started/after/vpa-Updater.yaml
@@ -17,6 +17,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/reconcile-for-the-single-container-pod-gathering-data-finished/after/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-gathering-data-finished/after/vpa-Updater.yaml
@@ -17,6 +17,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/reconcile-for-the-single-container-pod-hpa-changed/after/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-hpa-changed/after/vpa-Updater.yaml
@@ -17,6 +17,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/reconcile-for-the-single-container-pod-partly-working/after/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-partly-working/after/vpa-Updater.yaml
@@ -17,6 +17,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/reconcile-for-the-single-container-pod-suggested-too-small/after/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-suggested-too-small/after/vpa-Updater.yaml
@@ -17,6 +17,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/testdata/reconcile-for-the-single-container-pod-working/after/vpa-Updater.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-working/after/vpa-Updater.yaml
@@ -17,6 +17,10 @@ spec:
   updatePolicy:
     updateMode: Initial
 status:
+  conditions:
+    - type: RecommendationProvided
+      status: "True"
+      Message: "The recommendation is provided from Tortoise(mercari)"
   recommendation:
     containerRecommendations:
     - containerName: app

--- a/controllers/tortoise_controller.go
+++ b/controllers/tortoise_controller.go
@@ -236,7 +236,7 @@ func (r *TortoiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_
 		return ctrl.Result{}, err
 	}
 
-	_, updated, err := r.VpaService.UpdateVPAFromTortoiseRecommendation(ctx, tortoise, currentReplicaNum)
+	_, updated, err := r.VpaService.UpdateVPAFromTortoiseRecommendation(ctx, tortoise, currentReplicaNum, now)
 	if err != nil {
 		logger.Error(err, "update VPA based on the recommendation in tortoise", "tortoise", req.NamespacedName)
 		return ctrl.Result{}, err


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/

Also, please read the contributor guide, which contains some general rules and suggestions:
https://github.com/mercari/tortoise/blob/main/docs/contributor-guide.md
-->

#### What this PR does / why we need it:

We'd like to reduce the frequency of Pod replacement. Currently, we replace Pods every time VPA suggests different values.

We can reduce, for example, by:
When VPA suggests scaling up, we scale up ASAP (otherwise might dangerous). But, when VPA suggests scaling down, we don't scale down very often. If VPA strongly wants to scale down, it should keep suggesting, and we can reduce the value in such case only.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #281

#### Special notes for your reviewer:
