### PR TITLE
Scale vertically when the replica number hits the upper limit

### DIFF
--- a/controllers/tortoise_controller_test.go
+++ b/controllers/tortoise_controller_test.go
@@ -172,7 +172,7 @@ func startController(ctx context.Context) func() {
 		VpaService:         cli,
 		DeploymentService:  deployment.New(mgr.GetClient(), "100m", "100Mi", recorder),
 		TortoiseService:    tortoiseService,
-		RecommenderService: recommender.New(2.0, 0.5, 90, 40, 3, 30, "10m", "10Mi", "10", "10Gi", recorder),
+		RecommenderService: recommender.New(2.0, 0.5, 90, 40, 3, 30, "10m", "10Mi", "10", "10Gi", 10000, recorder),
 	}
 	err = reconciler.SetupWithManager(mgr)
 	Expect(err).ShouldNot(HaveOccurred())

--- a/main.go
+++ b/main.go
@@ -158,7 +158,7 @@ func main() {
 		HpaService:         hpaService,
 		VpaService:         vpaClient,
 		DeploymentService:  deployment.New(mgr.GetClient(), config.IstioSidecarProxyDefaultCPU, config.IstioSidecarProxyDefaultMemory, eventRecorder),
-		RecommenderService: recommender.New(config.MaxReplicasFactor, config.MinReplicasFactor, config.UpperTargetResourceUtilization, config.MinimumTargetResourceUtilization, config.MinimumMinReplicas, config.PreferredReplicaNumUpperLimit, config.MinimumCPUCores, config.MinimumMemoryBytes, config.MaximumCPUCores, config.MaximumMemoryBytes, eventRecorder),
+		RecommenderService: recommender.New(config.MaxReplicasFactor, config.MinReplicasFactor, config.UpperTargetResourceUtilization, config.MinimumTargetResourceUtilization, config.MinimumMinReplicas, config.PreferredReplicaNumUpperLimit, config.MinimumCPUCores, config.MinimumMemoryBytes, config.MaximumCPUCores, config.MaximumMemoryBytes, config.MaximumMaxReplica, eventRecorder),
 		TortoiseService:    tortoiseService,
 		Interval:           config.TortoiseUpdateInterval,
 		EventRecorder:      eventRecorder,


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/

Also, please read the contributor guide, which contains some general rules and suggestions:
https://github.com/mercari/tortoise/blob/main/docs/contributor-guide.md
-->

#### What this PR does / why we need it:

We skip generating HPA recommendations if the current replica number is equal to the maximumMaxReplica
because HPA recommendation would be not valid in this case
and, either way, editing HPA would not change any situation because the replica number is already at the maximum.
		
But, in such cases, we still update VPA recommendations because VPA recommendations are not affected by the replica number
and hopefully making the container bigger would help the situation.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #292

#### Special notes for your reviewer:
