### PR TITLE
fix: reset tortoise_number metric correctly when tortoise changes mode

### DIFF
--- a/pkg/metrics/tortoisenumber.go
+++ b/pkg/metrics/tortoisenumber.go
@@ -9,14 +9,30 @@ func RecordTortoise(t *v1beta3.Tortoise, deleted bool) {
 	if deleted {
 		value = 0
 	}
-	TortoiseNumber.WithLabelValues(
-		t.Name,
-		t.Namespace,
-		t.Spec.TargetRefs.ScaleTargetRef.Name,
-		t.Spec.TargetRefs.ScaleTargetRef.Kind,
-		string(t.Spec.UpdateMode),
-		string(t.Status.TortoisePhase),
-	).Set(value)
+
+	for _, um := range []v1beta3.UpdateMode{v1beta3.UpdateModeOff, v1beta3.UpdateModeAuto, v1beta3.UpdateModeEmergency} {
+		if t.Spec.UpdateMode != um {
+			// Set 0 to reset.
+			TortoiseNumber.WithLabelValues(
+				t.Name,
+				t.Namespace,
+				t.Spec.TargetRefs.ScaleTargetRef.Name,
+				t.Spec.TargetRefs.ScaleTargetRef.Kind,
+				string(um),
+				string(t.Status.TortoisePhase),
+			).Set(0.0)
+			continue
+		}
+
+		TortoiseNumber.WithLabelValues(
+			t.Name,
+			t.Namespace,
+			t.Spec.TargetRefs.ScaleTargetRef.Name,
+			t.Spec.TargetRefs.ScaleTargetRef.Kind,
+			string(t.Spec.UpdateMode),
+			string(t.Status.TortoisePhase),
+		).Set(value)
+	}
 }
 
 func ShouldRerecordTortoise(old, new *v1beta3.Tortoise) bool {


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/

Also, please read the contributor guide, which contains some general rules and suggestions:
https://github.com/mercari/tortoise/blob/main/docs/contributor-guide.md
-->

#### What this PR does / why we need it:

Currently, when tortoise changes its mode, the old value isn't reset.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
