### PR TITLE
Maintain consistent naming scheme

### DIFF
--- a/pkg/annotation/annotation.go
+++ b/pkg/annotation/annotation.go
@@ -3,7 +3,7 @@ package annotation
 // annotation on HPA and VPA resource.
 const (
 	// TortoiseNameAnnotation - VPA and HPA managed by tortoise have this label.
-	TortoiseNameAnnotation = "tortoises.autoscaling.mercari.com/tortoise-name"
+	TortoiseNameAnnotation = "tortoise.autoscaling.mercari.com/tortoise-name"
 
 	// If this annotation is set to "true", it means that tortoise manages that resource,
 	// and will be removed when the tortoise is deleted.


### PR DESCRIPTION
Everywhere else we are using `tortoise.autoscaling.mercari.com` except here. Also I think only 1 Tortoise object should be the owner of an HPA (1:Many mapping) so this should be singular as well

<!--  
Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/

Also, please read the contributor guide, which contains some general rules and suggestions:
https://github.com/mercari/tortoise/blob/main/docs/contributor-guide.md
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
