### PR TITLE
stop depending on TortoiseNameAnnotation in HPA deletion mutating webhook

### DIFF
--- a/api/autoscaling/v2/horizontalpodautoscaler_webhook_test.go
+++ b/api/autoscaling/v2/horizontalpodautoscaler_webhook_test.go
@@ -166,14 +166,14 @@ var _ = Describe("v2.HPA Webhook", func() {
 		})
 	})
 	Context("validating", func() {
-		It("valid: HPA can be deleted when Tortoise (Off) exists", func() {
-			validateDeletionTest(filepath.Join("testdata", "validating", "hpa-with-off", "hpa.yaml"), filepath.Join("testdata", "validating", "hpa-with-off", "tortoise.yaml"), true)
+		It("invalid: HPA cannot be deleted when Tortoise (Auto) exists", func() {
+			validateDeletionTest(filepath.Join("testdata", "validating", "hpa-with-auto-existing", "hpa.yaml"), filepath.Join("testdata", "validating", "hpa-with-auto-existing", "tortoise.yaml"), false)
+		})
+		It("invalid: HPA can not be deleted when Tortoise (Off) exists", func() {
+			validateDeletionTest(filepath.Join("testdata", "validating", "hpa-with-off", "hpa.yaml"), filepath.Join("testdata", "validating", "hpa-with-off", "tortoise.yaml"), false)
 		})
 		It("valid: HPA can be deleted when Tortoise (Auto) is deleted", func() {
 			validateDeletionTest(filepath.Join("testdata", "validating", "hpa-with-auto-deleted", "hpa.yaml"), "", true)
-		})
-		It("invalid: HPA cannot be deleted when Tortoise (Auto) exists", func() {
-			validateDeletionTest(filepath.Join("testdata", "validating", "hpa-with-auto-existing", "hpa.yaml"), filepath.Join("testdata", "validating", "hpa-with-auto-existing", "tortoise.yaml"), false)
 		})
 		It("valid: HPA can be deleted when Tortoise (Auto) is being deleted", func() {
 			// create tortoise

--- a/api/autoscaling/v2/testdata/validating/hpa-with-auto-being-deleted/hpa.yaml
+++ b/api/autoscaling/v2/testdata/validating/hpa-with-auto-being-deleted/hpa.yaml
@@ -3,8 +3,6 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: sample
   namespace: default
-  annotations:
-    tortoises.autoscaling.mercari.com/tortoise-name: tortoise-sample
 spec:
   maxReplicas: 12
   metrics:

--- a/api/autoscaling/v2/testdata/validating/hpa-with-auto-deleted/hpa.yaml
+++ b/api/autoscaling/v2/testdata/validating/hpa-with-auto-deleted/hpa.yaml
@@ -3,8 +3,6 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: sample
   namespace: default
-  annotations:
-    tortoises.autoscaling.mercari.com/tortoise-name: tortoise-sample
 spec:
   maxReplicas: 12
   metrics:

--- a/api/autoscaling/v2/testdata/validating/hpa-with-auto-existing/hpa.yaml
+++ b/api/autoscaling/v2/testdata/validating/hpa-with-auto-existing/hpa.yaml
@@ -3,8 +3,6 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: sample
   namespace: default
-  annotations:
-    tortoises.autoscaling.mercari.com/tortoise-name: tortoise-sample
 spec:
   maxReplicas: 12
   metrics:

--- a/api/autoscaling/v2/testdata/validating/hpa-with-off/hpa.yaml
+++ b/api/autoscaling/v2/testdata/validating/hpa-with-off/hpa.yaml
@@ -3,8 +3,6 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: sample
   namespace: default
-  annotations:
-    tortoises.autoscaling.mercari.com/tortoise-name: tortoise-sample
 spec:
   maxReplicas: 12
   metrics:

--- a/pkg/tortoise/tortoise.go
+++ b/pkg/tortoise/tortoise.go
@@ -391,6 +391,16 @@ func (s *Service) GetTortoise(ctx context.Context, namespacedName types.Namespac
 	return t, nil
 }
 
+func (s *Service) ListTortoise(ctx context.Context, namespaceName string) (*v1beta3.TortoiseList, error) {
+	tl := &v1beta3.TortoiseList{}
+	if err := s.c.List(ctx, tl, &client.ListOptions{
+		Namespace: namespaceName,
+	}); err != nil {
+		return nil, fmt.Errorf("failed to list tortoise in %s: %w", namespaceName, err)
+	}
+	return tl, nil
+}
+
 func (s *Service) AddFinalizer(ctx context.Context, tortoise *v1beta3.Tortoise) (*v1beta3.Tortoise, error) {
 	if controllerutil.ContainsFinalizer(tortoise, tortoiseFinalizer) {
 		return tortoise, nil


### PR DESCRIPTION

<!--  
Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/

Also, please read the contributor guide, which contains some general rules and suggestions:
https://github.com/mercari/tortoise/blob/main/docs/contributor-guide.md
-->

#### What this PR does / why we need it:

stop depending on TortoiseNameAnnotation in HPA deletion mutating webhook because Off Tortoise does not have the annotation. So, if we change Tortoise to Auto and try to delete HPA at once, HPA may be deleted even though Tortoise refers to it.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
