### PR TITLE
fix: ignore 0 policy instead of `nil` in mutating webhook

### DIFF
--- a/api/v1beta3/testdata/mutating/no-autoscaling-policy/before.yaml
+++ b/api/v1beta3/testdata/mutating/no-autoscaling-policy/before.yaml
@@ -4,8 +4,7 @@ metadata:
   name: tortoise-sample
   namespace: default
 spec:
-  updateMode: "Off"
-  deletionPolicy: "NoDelete"
+  autoscalingPolicy: []
   targetRefs:
     scaleTargetRef:
       kind: Deployment

--- a/api/v1beta3/tortoise_webhook.go
+++ b/api/v1beta3/tortoise_webhook.go
@@ -65,7 +65,7 @@ func TortoiseDefaultHPAName(tortoiseName string) string {
 func (r *Tortoise) defaultAutoscalingPolicy() {
 	ctx := context.Background()
 
-	if r.Spec.AutoscalingPolicy == nil {
+	if len(r.Spec.AutoscalingPolicy) == 0 {
 		return
 	}
 


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/

Also, please read the contributor guide, which contains some general rules and suggestions:
https://github.com/mercari/tortoise/blob/main/docs/contributor-guide.md
-->

#### What this PR does / why we need it:

If you create the below tortoise via `kubectl`, `autoscalingPolicy` isn't interpreted as nil in mutating webhook.

```
apiVersion: autoscaling.mercari.com/v1beta3
kind: Tortoise
metadata:
  name: hoge
  namespace: sample
spec:
  autoscalingPolicy: []
  targetRefs:
    horizontalPodAutoscalerName: hoge
    scaleTargetRef:
      apiVersion: apps/v1
      kind: Deployment
      name: hoge
  updateMode: "Off"
```

It's weird that we cannot catch this bug in the webhook integration test, (probably) because the test doesn't use `kubectl` - guessing how to interpret `[]` in yaml is different between `kubectl` and the integration test ("k8s.io/apimachinery/pkg/util/yaml").

So, it tries to use `len` to determine when to ignore.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
