### PR TITLE
scale up based on PreferredMaxReplicas only once 30mins

### DIFF
--- a/api/v1beta3/tortoise_types.go
+++ b/api/v1beta3/tortoise_types.go
@@ -344,8 +344,9 @@ type TortoiseConditionType string
 
 const (
 	// TortoiseConditionTypeFailedToReconcile means tortoise failed to reconcile due to some reasons.
-	TortoiseConditionTypeFailedToReconcile           TortoiseConditionType = "FailedToReconcile"
-	TortoiseConditionTypeHPATargetUtilizationUpdated TortoiseConditionType = "HPATargetUtilizationUpdated"
+	TortoiseConditionTypeFailedToReconcile                   TortoiseConditionType = "FailedToReconcile"
+	TortoiseConditionTypeHPATargetUtilizationUpdated         TortoiseConditionType = "HPATargetUtilizationUpdated"
+	TortoiseConditionTypeScaledUpBasedOnPreferredMaxReplicas TortoiseConditionType = "ScaledUpBasedOnPreferredMaxReplicas"
 )
 
 type TortoiseCondition struct {

--- a/controllers/testdata/mutable-autoscalingpolicy-add-another-horizontal/after/tortoise.yaml
+++ b/controllers/testdata/mutable-autoscalingpolicy-add-another-horizontal/after/tortoise.yaml
@@ -63,10 +63,21 @@ status:
     tortoiseConditions:
     - lastTransitionTime: "2023-01-01T00:00:00Z"
       lastUpdateTime: "2023-01-01T00:00:00Z"
+      message: the current number of replicas is not bigger than the preferred max
+        replica number
+      reason: ScaledUpBasedOnPreferredMaxReplicas
+      status: "False"
+      type: ScaledUpBasedOnPreferredMaxReplicas
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
       message: HPA target utilization is updated
       reason: HPATargetUtilizationUpdated
       status: "True"
       type: HPATargetUtilizationUpdated
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/mutable-autoscalingpolicy-no-hpa-and-add-horizontal/after/tortoise.yaml
+++ b/controllers/testdata/mutable-autoscalingpolicy-no-hpa-and-add-horizontal/after/tortoise.yaml
@@ -63,10 +63,21 @@ status:
     tortoiseConditions:
     - lastTransitionTime: "2023-01-01T00:00:00Z"
       lastUpdateTime: "2023-01-01T00:00:00Z"
+      message: the current number of replicas is not bigger than the preferred max
+        replica number
+      reason: ScaledUpBasedOnPreferredMaxReplicas
+      status: "False"
+      type: ScaledUpBasedOnPreferredMaxReplicas
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
       message: HPA target utilization is updated
       reason: HPATargetUtilizationUpdated
       status: "True"
       type: HPATargetUtilizationUpdated
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/mutable-autoscalingpolicy-remove-horizontal-2/after/tortoise.yaml
+++ b/controllers/testdata/mutable-autoscalingpolicy-remove-horizontal-2/after/tortoise.yaml
@@ -70,7 +70,11 @@ status:
       resource:
         cpu: "3"
         memory: 3Gi
-    tortoiseConditions: null
+    tortoiseConditions:
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/mutable-autoscalingpolicy-remove-horizontal/after/tortoise.yaml
+++ b/controllers/testdata/mutable-autoscalingpolicy-remove-horizontal/after/tortoise.yaml
@@ -69,7 +69,11 @@ status:
       resource:
         cpu: "3"
         memory: 3Gi
-    tortoiseConditions: null
+    tortoiseConditions:
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-istio-enabled-pod-working/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-istio-enabled-pod-working/after/tortoise.yaml
@@ -63,10 +63,21 @@ status:
     tortoiseConditions:
     - lastTransitionTime: "2023-01-01T00:00:00Z"
       lastUpdateTime: "2023-01-01T00:00:00Z"
+      message: the current number of replicas is not bigger than the preferred max
+        replica number
+      reason: ScaledUpBasedOnPreferredMaxReplicas
+      status: "False"
+      type: ScaledUpBasedOnPreferredMaxReplicas
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
       message: HPA target utilization is updated
       reason: HPATargetUtilizationUpdated
       status: "True"
       type: HPATargetUtilizationUpdated
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-multiple-containers-pod-all-off/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-multiple-containers-pod-all-off/after/tortoise.yaml
@@ -60,7 +60,11 @@ status:
       resource:
         cpu: "4"
         memory: 4Gi
-    tortoiseConditions: null
+    tortoiseConditions:
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-multiple-containers-pod-all-vertical/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-multiple-containers-pod-all-vertical/after/tortoise.yaml
@@ -60,7 +60,11 @@ status:
       resource:
         cpu: "3"
         memory: 3Gi
-    tortoiseConditions: null
+    tortoiseConditions:
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-multiple-containers-pod-during-emergency/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-multiple-containers-pod-during-emergency/after/tortoise.yaml
@@ -68,6 +68,10 @@ status:
       reason: HPATargetUtilizationUpdated
       status: "True"
       type: HPATargetUtilizationUpdated
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-multiple-containers-pod-emergency-started/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-multiple-containers-pod-emergency-started/after/tortoise.yaml
@@ -68,6 +68,10 @@ status:
       reason: HPATargetUtilizationUpdated
       status: "True"
       type: HPATargetUtilizationUpdated
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-multiple-containers-pod-one-off/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-multiple-containers-pod-one-off/after/tortoise.yaml
@@ -63,10 +63,21 @@ status:
     tortoiseConditions:
     - lastTransitionTime: "2023-01-01T00:00:00Z"
       lastUpdateTime: "2023-01-01T00:00:00Z"
+      message: the current number of replicas is not bigger than the preferred max
+        replica number
+      reason: ScaledUpBasedOnPreferredMaxReplicas
+      status: "False"
+      type: ScaledUpBasedOnPreferredMaxReplicas
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
       message: HPA target utilization is updated
       reason: HPATargetUtilizationUpdated
       status: "True"
       type: HPATargetUtilizationUpdated
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-multiple-containers-pod-suggested-too-small/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-multiple-containers-pod-suggested-too-small/after/tortoise.yaml
@@ -63,10 +63,21 @@ status:
     tortoiseConditions:
     - lastTransitionTime: "2023-01-01T00:00:00Z"
       lastUpdateTime: "2023-01-01T00:00:00Z"
+      message: the current number of replicas is not bigger than the preferred max
+        replica number
+      reason: ScaledUpBasedOnPreferredMaxReplicas
+      status: "False"
+      type: ScaledUpBasedOnPreferredMaxReplicas
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
       message: HPA target utilization is updated
       reason: HPATargetUtilizationUpdated
       status: "True"
       type: HPATargetUtilizationUpdated
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-multiple-containers-pod-working/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-multiple-containers-pod-working/after/tortoise.yaml
@@ -63,10 +63,21 @@ status:
     tortoiseConditions:
     - lastTransitionTime: "2023-01-01T00:00:00Z"
       lastUpdateTime: "2023-01-01T00:00:00Z"
+      message: the current number of replicas is not bigger than the preferred max
+        replica number
+      reason: ScaledUpBasedOnPreferredMaxReplicas
+      status: "False"
+      type: ScaledUpBasedOnPreferredMaxReplicas
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
       message: HPA target utilization is updated
       reason: HPATargetUtilizationUpdated
       status: "True"
       type: HPATargetUtilizationUpdated
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-single-container-pod-backtonormal/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-backtonormal/after/tortoise.yaml
@@ -45,6 +45,10 @@ status:
       reason: HPATargetUtilizationUpdated
       status: "True"
       type: HPATargetUtilizationUpdated
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-single-container-pod-dryrun/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-dryrun/after/tortoise.yaml
@@ -38,7 +38,18 @@ status:
       resource:
         cpu: "4"
         memory: 4Gi
-    tortoiseConditions: null
+    tortoiseConditions:
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      message: the current number of replicas is not bigger than the preferred max
+        replica number
+      reason: ScaledUpBasedOnPreferredMaxReplicas
+      status: "False"
+      type: ScaledUpBasedOnPreferredMaxReplicas
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-single-container-pod-during-emergency/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-during-emergency/after/tortoise.yaml
@@ -45,6 +45,10 @@ status:
       reason: HPATargetUtilizationUpdated
       status: "True"
       type: HPATargetUtilizationUpdated
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-single-container-pod-emergency-started/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-emergency-started/after/tortoise.yaml
@@ -45,6 +45,10 @@ status:
       reason: HPATargetUtilizationUpdated
       status: "True"
       type: HPATargetUtilizationUpdated
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-single-container-pod-gathering-data-finished/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-gathering-data-finished/after/tortoise.yaml
@@ -40,10 +40,21 @@ status:
     tortoiseConditions:
     - lastTransitionTime: "2023-01-01T00:00:00Z"
       lastUpdateTime: "2023-01-01T00:00:00Z"
+      message: the current number of replicas is not bigger than the preferred max
+        replica number
+      reason: ScaledUpBasedOnPreferredMaxReplicas
+      status: "False"
+      type: ScaledUpBasedOnPreferredMaxReplicas
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
       message: HPA target utilization is updated
       reason: HPATargetUtilizationUpdated
       status: "True"
       type: HPATargetUtilizationUpdated
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-single-container-pod-gathering-data/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-gathering-data/after/tortoise.yaml
@@ -37,7 +37,18 @@ status:
       resource:
         cpu: "4"
         memory: 4Gi
-    tortoiseConditions: null
+    tortoiseConditions:
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      message: the current number of replicas is not bigger than the preferred max
+        replica number
+      reason: ScaledUpBasedOnPreferredMaxReplicas
+      status: "False"
+      type: ScaledUpBasedOnPreferredMaxReplicas
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-single-container-pod-hpa-changed/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-hpa-changed/after/tortoise.yaml
@@ -41,10 +41,21 @@ status:
     tortoiseConditions:
     - lastTransitionTime: "2023-01-01T00:00:00Z"
       lastUpdateTime: "2023-01-01T00:00:00Z"
+      message: the current number of replicas is not bigger than the preferred max
+        replica number
+      reason: ScaledUpBasedOnPreferredMaxReplicas
+      status: "False"
+      type: ScaledUpBasedOnPreferredMaxReplicas
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
       message: HPA target utilization is updated
       reason: HPATargetUtilizationUpdated
       status: "True"
       type: HPATargetUtilizationUpdated
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-single-container-pod-initializing/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-initializing/after/tortoise.yaml
@@ -38,7 +38,11 @@ status:
       resource:
         cpu: "4"
         memory: 4Gi
-    tortoiseConditions: null
+    tortoiseConditions:
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-single-container-pod-partly-working/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-partly-working/after/tortoise.yaml
@@ -40,10 +40,21 @@ status:
     tortoiseConditions:
     - lastTransitionTime: "2023-01-01T00:00:00Z"
       lastUpdateTime: "2023-01-01T00:00:00Z"
+      message: the current number of replicas is not bigger than the preferred max
+        replica number
+      reason: ScaledUpBasedOnPreferredMaxReplicas
+      status: "False"
+      type: ScaledUpBasedOnPreferredMaxReplicas
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
       message: HPA target utilization is updated
       reason: HPATargetUtilizationUpdated
       status: "True"
       type: HPATargetUtilizationUpdated
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/controllers/testdata/reconcile-for-the-single-container-pod-working/after/tortoise.yaml
+++ b/controllers/testdata/reconcile-for-the-single-container-pod-working/after/tortoise.yaml
@@ -40,10 +40,21 @@ status:
     tortoiseConditions:
     - lastTransitionTime: "2023-01-01T00:00:00Z"
       lastUpdateTime: "2023-01-01T00:00:00Z"
+      message: the current number of replicas is not bigger than the preferred max
+        replica number
+      reason: ScaledUpBasedOnPreferredMaxReplicas
+      status: "False"
+      type: ScaledUpBasedOnPreferredMaxReplicas
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
       message: HPA target utilization is updated
       reason: HPATargetUtilizationUpdated
       status: "True"
       type: HPATargetUtilizationUpdated
+    - lastTransitionTime: "2023-01-01T00:00:00Z"
+      lastUpdateTime: "2023-01-01T00:00:00Z"
+      status: "False"
+      type: FailedToReconcile
   containerResourcePhases:
   - containerName: app
     resourcePhases:

--- a/pkg/recommender/recommender_test.go
+++ b/pkg/recommender/recommender_test.go
@@ -1567,6 +1567,7 @@ func Test_updateHPAMinMaxReplicasRecommendations(t *testing.T) {
 }
 
 func TestService_UpdateVPARecommendation(t *testing.T) {
+	now := time.Now()
 	type fields struct {
 		preferredMaxReplicas       int32
 		minimumMinReplicas         int32
@@ -1650,7 +1651,14 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 						},
 					},
 				},
-			).AddContainerResourceRequests(v1beta3.ContainerResourceRequests{
+			).AddTortoiseConditions(v1beta3.TortoiseCondition{
+				Type:               v1beta3.TortoiseConditionTypeScaledUpBasedOnPreferredMaxReplicas,
+				Status:             corev1.ConditionTrue,
+				Reason:             "ScaledUpBasedOnPreferredMaxReplicas",
+				Message:            "the current number of replicas is bigger than the preferred max replica number",
+				LastTransitionTime: metav1.NewTime(now),
+				LastUpdateTime:     metav1.NewTime(now),
+			}).AddContainerResourceRequests(v1beta3.ContainerResourceRequests{
 				ContainerName: "test-container",
 				Resource:      createResourceList("500m", "500Mi"),
 			}).SetRecommendations(v1beta3.Recommendations{
@@ -1658,7 +1666,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 					ContainerResourceRecommendation: []v1beta3.RecommendedContainerResources{
 						{
 							ContainerName:       "test-container",
-							RecommendedResource: createResourceList("550m", "550Mi"), // current * 1.1
+							RecommendedResource: createResourceList("650m", "650Mi"), // current * 1.1
 						},
 					},
 				},
@@ -1926,7 +1934,14 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 						},
 					},
 				},
-			).AddContainerResourceRequests(v1beta3.ContainerResourceRequests{
+			).AddTortoiseConditions(v1beta3.TortoiseCondition{
+				Type:               v1beta3.TortoiseConditionTypeScaledUpBasedOnPreferredMaxReplicas,
+				Status:             corev1.ConditionTrue,
+				Reason:             "ScaledUpBasedOnPreferredMaxReplicas",
+				Message:            "the current number of replicas is bigger than the preferred max replica number",
+				LastTransitionTime: metav1.NewTime(now),
+				LastUpdateTime:     metav1.NewTime(now),
+			}).AddContainerResourceRequests(v1beta3.ContainerResourceRequests{
 				ContainerName: "test-container",
 				Resource:      createResourceList("500m", "500Mi"),
 			}).SetRecommendations(v1beta3.Recommendations{
@@ -1934,7 +1949,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 					ContainerResourceRecommendation: []v1beta3.RecommendedContainerResources{
 						{
 							ContainerName:       "test-container",
-							RecommendedResource: createResourceList("550m" /* current * 1.1*/, "800Mi" /* VPA recommendation*/),
+							RecommendedResource: createResourceList("650m" /* current * 1.1*/, "800Mi" /* VPA recommendation*/),
 						},
 					},
 				},
@@ -2024,7 +2039,14 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 						},
 					},
 				},
-			).AddContainerResourceRequests(v1beta3.ContainerResourceRequests{
+			).AddTortoiseConditions(v1beta3.TortoiseCondition{
+				Type:               v1beta3.TortoiseConditionTypeScaledUpBasedOnPreferredMaxReplicas,
+				Status:             corev1.ConditionFalse,
+				Reason:             "ScaledUpBasedOnPreferredMaxReplicas",
+				Message:            "the current number of replicas is not bigger than the preferred max replica number",
+				LastTransitionTime: metav1.NewTime(now),
+				LastUpdateTime:     metav1.NewTime(now),
+			}).AddContainerResourceRequests(v1beta3.ContainerResourceRequests{
 				ContainerName: "test-container",
 				Resource:      createResourceList("1500m", "1.5Gi"),
 			}).SetRecommendations(v1beta3.Recommendations{
@@ -2125,6 +2147,13 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			).AddContainerResourceRequests(v1beta3.ContainerResourceRequests{
 				ContainerName: "test-container",
 				Resource:      createResourceList("15m", "1.5Mi"), //smaller than MinAllocatedResources
+			}).AddTortoiseConditions(v1beta3.TortoiseCondition{
+				Type:               v1beta3.TortoiseConditionTypeScaledUpBasedOnPreferredMaxReplicas,
+				Status:             corev1.ConditionFalse,
+				Reason:             "ScaledUpBasedOnPreferredMaxReplicas",
+				Message:            "the current number of replicas is not bigger than the preferred max replica number",
+				LastTransitionTime: metav1.NewTime(now),
+				LastUpdateTime:     metav1.NewTime(now),
 			}).SetRecommendations(v1beta3.Recommendations{
 				Vertical: v1beta3.VerticalRecommendations{
 					ContainerResourceRecommendation: []v1beta3.RecommendedContainerResources{
@@ -2203,6 +2232,13 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			).AddContainerResourceRequests(v1beta3.ContainerResourceRequests{
 				ContainerName: "test-container",
 				Resource:      createResourceList("130m", "130Mi"),
+			}).AddTortoiseConditions(v1beta3.TortoiseCondition{
+				Type:               v1beta3.TortoiseConditionTypeScaledUpBasedOnPreferredMaxReplicas,
+				Status:             corev1.ConditionFalse,
+				Reason:             "ScaledUpBasedOnPreferredMaxReplicas",
+				Message:            "the current number of replicas is not bigger than the preferred max replica number",
+				LastTransitionTime: metav1.NewTime(now),
+				LastUpdateTime:     metav1.NewTime(now),
 			}).SetRecommendations(v1beta3.Recommendations{
 				Vertical: v1beta3.VerticalRecommendations{
 					ContainerResourceRecommendation: []v1beta3.RecommendedContainerResources{
@@ -2763,6 +2799,13 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 						},
 					},
 				},
+			}).AddTortoiseConditions(v1beta3.TortoiseCondition{
+				Type:               v1beta3.TortoiseConditionTypeScaledUpBasedOnPreferredMaxReplicas,
+				Status:             corev1.ConditionFalse,
+				Reason:             "ScaledUpBasedOnPreferredMaxReplicas",
+				Message:            "the current number of replicas is not bigger than the preferred max replica number",
+				LastTransitionTime: metav1.NewTime(now),
+				LastUpdateTime:     metav1.NewTime(now),
 			}).Build(),
 			wantErr: false,
 		},
@@ -2771,7 +2814,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 
 			s := New(0, 0, 0, 0, int(tt.fields.minimumMinReplicas), int(tt.fields.preferredMaxReplicas), "5m", "5Mi", map[string]string{"istio-proxy": "7m"}, map[string]string{"istio-proxy": "7Mi"}, tt.fields.maxCPU, tt.fields.maxMemory, 10000, tt.fields.maxAllowedScalingDownRatio, tt.fields.features, record.NewFakeRecorder(10))
-			got, err := s.updateVPARecommendation(context.Background(), tt.args.tortoise, tt.args.hpa, tt.args.replicaNum)
+			got, err := s.updateVPARecommendation(context.Background(), tt.args.tortoise, tt.args.hpa, tt.args.replicaNum, now)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("updateVPARecommendation() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/tortoise/tortoise.go
+++ b/pkg/tortoise/tortoise.go
@@ -479,41 +479,10 @@ func (s *Service) updateLastTimeUpdateTortoise(tortoise *v1beta3.Tortoise, now t
 func (s *Service) RecordReconciliationFailure(t *v1beta3.Tortoise, err error, now time.Time) *v1beta3.Tortoise {
 	if err != nil {
 		s.recorder.Event(t, "Warning", "ReconcileError", err.Error())
-		for i := range t.Status.Conditions.TortoiseConditions {
-			if t.Status.Conditions.TortoiseConditions[i].Type == v1beta3.TortoiseConditionTypeFailedToReconcile {
-				// TODO: have a clear reason and utilize it to have a better reconciliation next.
-				// For example, in some cases, the reconciliation may keep failing until people fix some problems manually.
-				t.Status.Conditions.TortoiseConditions[i].Reason = "ReconcileError"
-				t.Status.Conditions.TortoiseConditions[i].Message = err.Error()
-				t.Status.Conditions.TortoiseConditions[i].Status = corev1.ConditionTrue
-				t.Status.Conditions.TortoiseConditions[i].LastTransitionTime = metav1.NewTime(now)
-				t.Status.Conditions.TortoiseConditions[i].LastUpdateTime = metav1.NewTime(now)
-				return t
-			}
-		}
-		// add as a new condition if not found.
-		t.Status.Conditions.TortoiseConditions = append(t.Status.Conditions.TortoiseConditions, v1beta3.TortoiseCondition{
-			Type:               v1beta3.TortoiseConditionTypeFailedToReconcile,
-			Status:             corev1.ConditionTrue,
-			Reason:             "ReconcileError",
-			Message:            err.Error(),
-			LastTransitionTime: metav1.NewTime(now),
-			LastUpdateTime:     metav1.NewTime(now),
-		})
-		return t
+		return utils.ChangeTortoiseCondition(t, v1beta3.TortoiseConditionTypeFailedToReconcile, corev1.ConditionTrue, "ReconcileError", err.Error(), now)
 	}
 
-	for i := range t.Status.Conditions.TortoiseConditions {
-		if t.Status.Conditions.TortoiseConditions[i].Type == v1beta3.TortoiseConditionTypeFailedToReconcile {
-			t.Status.Conditions.TortoiseConditions[i].Reason = ""
-			t.Status.Conditions.TortoiseConditions[i].Message = ""
-			t.Status.Conditions.TortoiseConditions[i].Status = corev1.ConditionFalse
-			t.Status.Conditions.TortoiseConditions[i].LastTransitionTime = metav1.NewTime(now)
-			t.Status.Conditions.TortoiseConditions[i].LastUpdateTime = metav1.NewTime(now)
-			return t
-		}
-	}
-	return t
+	return utils.ChangeTortoiseCondition(t, v1beta3.TortoiseConditionTypeFailedToReconcile, corev1.ConditionFalse, "", "", now)
 }
 
 type resourceNameAndContainerName struct {

--- a/pkg/utils/tortoise.go
+++ b/pkg/utils/tortoise.go
@@ -9,6 +9,30 @@ import (
 	"github.com/mercari/tortoise/api/v1beta3"
 )
 
+func ChangeTortoiseCondition(t *v1beta3.Tortoise, conditionType v1beta3.TortoiseConditionType, status corev1.ConditionStatus, reason, message string, now time.Time) *v1beta3.Tortoise {
+	for i := range t.Status.Conditions.TortoiseConditions {
+		if t.Status.Conditions.TortoiseConditions[i].Type == conditionType {
+			t.Status.Conditions.TortoiseConditions[i].Reason = reason
+			t.Status.Conditions.TortoiseConditions[i].Message = message
+			t.Status.Conditions.TortoiseConditions[i].Status = status
+			t.Status.Conditions.TortoiseConditions[i].LastTransitionTime = metav1.NewTime(now)
+			t.Status.Conditions.TortoiseConditions[i].LastUpdateTime = metav1.NewTime(now)
+			return t
+		}
+	}
+	// add a new condition if not found.
+	t.Status.Conditions.TortoiseConditions = append(t.Status.Conditions.TortoiseConditions, v1beta3.TortoiseCondition{
+		Type:               conditionType,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.NewTime(now),
+		LastUpdateTime:     metav1.NewTime(now),
+	})
+
+	return t
+}
+
 func ChangeTortoiseResourcePhase(tortoise *v1beta3.Tortoise, containerName string, rn corev1.ResourceName, now time.Time, phase v1beta3.ContainerResourcePhase) *v1beta3.Tortoise {
 	found := false
 	for i, p := range tortoise.Status.ContainerResourcePhases {

--- a/pkg/utils/tortoise_builder.go
+++ b/pkg/utils/tortoise_builder.go
@@ -63,6 +63,11 @@ func (b *TortoiseBuilder) AddContainerResourceRequests(actualContainerResource v
 	return b
 }
 
+func (b *TortoiseBuilder) AddTortoiseConditions(condition v1beta3.TortoiseCondition) *TortoiseBuilder {
+	b.tortoise.Status.Conditions.TortoiseConditions = append(b.tortoise.Status.Conditions.TortoiseConditions, condition)
+	return b
+}
+
 func (b *TortoiseBuilder) SetRecommendations(recommendations v1beta3.Recommendations) *TortoiseBuilder {
 	b.tortoise.Status.Recommendations = recommendations
 	return b


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/

Also, please read the contributor guide, which contains some general rules and suggestions:
https://github.com/mercari/tortoise/blob/main/docs/contributor-guide.md
-->

#### What this PR does / why we need it:

scale up based on PreferredMaxReplicas only once 30mins to prevent too frequent vertical scaling up.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Part of #329

#### Special notes for your reviewer:
