### PR TITLE
fix nil pointer when `.Status.Recommendation` is nil

### DIFF
--- a/pkg/vpa/service.go
+++ b/pkg/vpa/service.go
@@ -116,6 +116,11 @@ func (c *Service) DisableTortoiseUpdaterVPA(ctx context.Context, tortoise *autos
 			}
 			return fmt.Errorf("get tortoise VPA: %w", err)
 		}
+		if oldVPA.Status.Recommendation == nil {
+			// Already no recommendation.
+			return nil
+		}
+
 		// Remove the recommendation from the VPA.
 		oldVPA.Status.Recommendation.ContainerRecommendations = nil
 


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/

Also, please read the contributor guide, which contains some general rules and suggestions:
https://github.com/mercari/tortoise/blob/main/docs/contributor-guide.md
-->

#### What this PR does / why we need it:

ssia

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
