### PR TITLE
add addtional resources on top of VPA recommendation for less frequent scaling up

### DIFF
--- a/pkg/recommender/recommender_test.go
+++ b/pkg/recommender/recommender_test.go
@@ -1624,7 +1624,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				}).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "test-container",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("500m"),
 							},
@@ -1651,7 +1651,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			}).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "test-container",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("500m"),
 						},
@@ -1730,7 +1730,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				}).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "test-container",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("500m"),
 							},
@@ -1757,7 +1757,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			}).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "test-container",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("500m"),
 						},
@@ -1844,7 +1844,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				}).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "test-container",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("400m"),
 							},
@@ -1871,7 +1871,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			}).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "test-container",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("400m"),
 						},
@@ -1951,7 +1951,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				}).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "test-container",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("400m"),
 							},
@@ -1978,7 +1978,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			}).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "test-container",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("400m"),
 						},
@@ -2050,7 +2050,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				}).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "test-container",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("400m"),
 							},
@@ -2077,7 +2077,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			}).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "test-container",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("400m"),
 						},
@@ -2136,7 +2136,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				}).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "test-container",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("500m"),
 							},
@@ -2163,7 +2163,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			}).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "test-container",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("500m"),
 						},
@@ -2214,7 +2214,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				}).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "test-container",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("1500m"), // exceed maxResourceSize
 							},
@@ -2268,7 +2268,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			}).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "test-container",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("1500m"),
 						},
@@ -2319,7 +2319,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				}).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "test-container",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("15m"), // smaller than MinAllocatedResources
 							},
@@ -2373,7 +2373,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			}).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "test-container",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("15m"), // smaller than MinAllocatedResources
 						},
@@ -2431,7 +2431,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				}).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "test-container",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("120m"),
 							},
@@ -2458,7 +2458,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			}).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "test-container",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("120m"),
 						},
@@ -2515,7 +2515,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				}).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "test-container",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("120m"),
 							},
@@ -2542,7 +2542,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			}).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "test-container",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("120m"),
 						},
@@ -2567,7 +2567,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "all vertical: reduce resources based on VPA recommendation plus bufferRatioOnVerticalResource",
+			name: "all vertical: scale resources based on VPA recommendation plus bufferRatioOnVerticalResource",
 			fields: fields{
 				preferredMaxReplicas:          6,
 				maxCPU:                        "1000m",
@@ -2593,7 +2593,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				}).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "test-container",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("120m"),
 							},
@@ -2620,7 +2620,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			}).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "test-container",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("120m"),
 						},
@@ -2636,8 +2636,103 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				Vertical: v1beta3.VerticalRecommendations{
 					ContainerResourceRecommendation: []v1beta3.RecommendedContainerResources{
 						{
-							ContainerName:       "test-container",
-							RecommendedResource: createResourceList("132m", "132Mi"), // VPA recommendation * (1 + bufferRatioOnVerticalResource)
+							ContainerName: "test-container",
+							// VPA recommendation * (1 + bufferRatioOnVerticalResource) * (1 + bufferRatioOnVerticalResource)
+							RecommendedResource: createResourceList("145m", "145.2Mi"),
+						},
+					},
+				},
+			}).Build(),
+			wantErr: false,
+		},
+		{
+			name: "all vertical: scale down resources based on VPA recommendation plus bufferRatioOnVerticalResource",
+			fields: fields{
+				preferredMaxReplicas:          6,
+				maxCPU:                        "1000m",
+				maxMemory:                     "1Gi",
+				bufferRatioOnVerticalResource: 0.1,
+			},
+			args: args{
+				hpa: &v2.HorizontalPodAutoscaler{
+					Spec: v2.HorizontalPodAutoscalerSpec{
+						MinReplicas: ptr.To[int32](1),
+						Metrics:     []v2.MetricSpec{},
+					},
+				},
+				tortoise: utils.NewTortoiseBuilder().AddAutoscalingPolicy(v1beta3.ContainerAutoscalingPolicy{
+					ContainerName: "test-container",
+					Policy: map[corev1.ResourceName]v1beta3.AutoscalingType{
+						corev1.ResourceCPU:    v1beta3.AutoscalingTypeVertical,
+						corev1.ResourceMemory: v1beta3.AutoscalingTypeVertical,
+					},
+				}).AddResourcePolicy(v1beta3.ContainerResourcePolicy{
+					ContainerName:         "test-container",
+					MinAllocatedResources: createResourceList("100m", "100Mi"),
+				}).AddContainerRecommendationFromVPA(
+					v1beta3.ContainerRecommendationFromVPA{
+						ContainerName: "test-container",
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+							corev1.ResourceCPU: {
+								// ideal = 110m
+								Quantity: resource.MustParse("100m"),
+							},
+							corev1.ResourceMemory: {
+								// ideal = 121Mi
+								Quantity: resource.MustParse("110Mi"),
+							},
+						},
+					},
+				).AddContainerResourceRequests(v1beta3.ContainerResourceRequests{
+					ContainerName: "test-container",
+					// Previous ideal = 132m, 132Mi
+					// Previous ideal * 0.9 = 118m, 118.8Mi
+					//
+					// → CPU will be scaled down to 110m
+					// → Memory will not be scaled down (because 118.8Mi < 121Mi)
+					Resource: createResourceList("145m", "145.2Mi"),
+				}).SetRecommendations(v1beta3.Recommendations{
+					Vertical: v1beta3.VerticalRecommendations{
+						ContainerResourceRecommendation: []v1beta3.RecommendedContainerResources{
+							{
+								ContainerName:       "test-container",
+								RecommendedResource: createResourceList("145m", "145.2Mi"),
+							},
+						},
+					},
+				}).Build(),
+			},
+			want: utils.NewTortoiseBuilder().AddAutoscalingPolicy(v1beta3.ContainerAutoscalingPolicy{
+				ContainerName: "test-container",
+				Policy: map[corev1.ResourceName]v1beta3.AutoscalingType{
+					corev1.ResourceCPU:    v1beta3.AutoscalingTypeVertical,
+					corev1.ResourceMemory: v1beta3.AutoscalingTypeVertical,
+				},
+			}).AddResourcePolicy(v1beta3.ContainerResourcePolicy{
+				ContainerName:         "test-container",
+				MinAllocatedResources: createResourceList("100m", "100Mi"),
+			}).AddContainerRecommendationFromVPA(
+				v1beta3.ContainerRecommendationFromVPA{
+					ContainerName: "test-container",
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						corev1.ResourceCPU: {
+							Quantity: resource.MustParse("100m"),
+						},
+						corev1.ResourceMemory: {
+							Quantity: resource.MustParse("110Mi"),
+						},
+					},
+				},
+			).AddContainerResourceRequests(v1beta3.ContainerResourceRequests{
+				ContainerName: "test-container",
+				Resource:      createResourceList("145m", "145.2Mi"),
+			}).SetRecommendations(v1beta3.Recommendations{
+				Vertical: v1beta3.VerticalRecommendations{
+					ContainerResourceRecommendation: []v1beta3.RecommendedContainerResources{
+						{
+							ContainerName: "test-container",
+							// VPA recommendation * (1 + bufferRatioOnVerticalResource) * (1 + bufferRatioOnVerticalResource)
+							RecommendedResource: createResourceList("110m", "145.2Mi"),
 						},
 					},
 				},
@@ -2670,7 +2765,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				}).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "test-container",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("10m"), // too small
 							},
@@ -2697,7 +2792,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			}).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "test-container",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("10m"),
 						},
@@ -2747,7 +2842,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				}).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "test-container",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("2m"),
 							},
@@ -2774,7 +2869,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			}).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "test-container",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("2m"),
 						},
@@ -2824,7 +2919,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				}).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "istio-proxy",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("2m"),
 							},
@@ -2851,7 +2946,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			}).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "istio-proxy",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("2m"),
 						},
@@ -2899,7 +2994,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				}).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "istio-proxy",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							// It's too small. They're overwriteen based on maxAllowedScalingDownRatio.
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("2m"),
@@ -2924,7 +3019,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			}).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "istio-proxy",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("2m"),
 						},
@@ -2977,7 +3072,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				}).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "test-container",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("80m"), // smaller than expectation (800m+)
 							},
@@ -2989,7 +3084,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 				).AddContainerRecommendationFromVPA(
 					v1beta3.ContainerRecommendationFromVPA{
 						ContainerName: "test-container2",
-						Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+						MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 							corev1.ResourceCPU: {
 								Quantity: resource.MustParse("800m"),
 							},
@@ -3075,7 +3170,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			}).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "test-container",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("80m"),
 						},
@@ -3087,7 +3182,7 @@ func TestService_UpdateVPARecommendation(t *testing.T) {
 			).AddContainerRecommendationFromVPA(
 				v1beta3.ContainerRecommendationFromVPA{
 					ContainerName: "test-container2",
-					Recommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
+					MaxRecommendation: map[corev1.ResourceName]v1beta3.ResourceQuantity{
 						corev1.ResourceCPU: {
 							Quantity: resource.MustParse("800m"),
 						},


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/

Also, please read the contributor guide, which contains some general rules and suggestions:
https://github.com/mercari/tortoise/blob/main/docs/contributor-guide.md
-->

#### What this PR does / why we need it:

This PR changes how Tortoise changes the resource requests.

Previously, we calculated the ideal size just by `(VPA recommendation) * (1+buffer ratio)`. (buffer ratio is 0.1, by default)
But, then every time VPA's recommendation changes, vertical scaling could happen, which increases the frequency of vertical scaling depending on the service's nature, especially scaling up because scaling down is limited to happening only once an hour anyways.

This PR changes it to the following:

##### scale up

Scale up always happens when the ideal size goes higher than the current resource request.
But, then, we don't just apply the ideal size, but apply `the ideal size * (1+buffer ratio)`.
Meaning, we increase the resource request more than actually needed,
which reduces the need of scaling up in the future.

##### scale down

We basically want to ignore too small scale down to reduce the frequency of restarts.
Every time we calculate the previous ideal value by `current resource req / (1+buffer ratio)`.
And, if the current ideal value is much smaller than the previous ideal value, we apply scaling down.

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
