### PR TITLE
use isSuperset for comparison in isMonitorVPAReady instead of Equals

### DIFF
--- a/pkg/vpa/service.go
+++ b/pkg/vpa/service.go
@@ -166,7 +166,7 @@ func isMonitorVPAReady(vpa *v1.VerticalPodAutoscaler, tortoise *autoscalingv1bet
 		}
 	}
 
-	return containerInTortoise.Equal(containerInVPA)
+	return containerInVPA.IsSuperset(containerInTortoise)
 }
 
 func SetAllVerticalContainerResourcePhaseWorking(tortoise *autoscalingv1beta3.Tortoise, now time.Time) *autoscalingv1beta3.Tortoise {

--- a/pkg/vpa/service_test.go
+++ b/pkg/vpa/service_test.go
@@ -628,6 +628,48 @@ func Test_isMonitorVPAReady(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Tortoise defines less containers than VPA, VPA is Ready",
+			args: args{
+				vpa: &vpav1.VerticalPodAutoscaler{
+					Status: vpav1.VerticalPodAutoscalerStatus{
+						Conditions: []vpav1.VerticalPodAutoscalerCondition{
+							{
+								Type:   vpav1.RecommendationProvided,
+								Status: v1.ConditionFalse,
+							},
+						},
+						Recommendation: &vpav1.RecommendedPodResources{
+							ContainerRecommendations: []vpav1.RecommendedContainerResources{
+								{
+									ContainerName: "app",
+									Target: v1.ResourceList{
+										v1.ResourceMemory: resource.MustParse("1Gi"),
+										v1.ResourceCPU:    resource.MustParse("1"), // wrong
+									},
+								},
+								{
+									ContainerName: "istio",
+									Target: v1.ResourceList{
+										v1.ResourceMemory: resource.MustParse("1Gi"),
+										v1.ResourceCPU:    resource.MustParse("1"),
+									},
+								},
+							},
+						},
+					},
+				},
+				tortoise: &autoscalingv1beta3.Tortoise{
+					Status: autoscalingv1beta3.TortoiseStatus{
+						AutoscalingPolicy: []autoscalingv1beta3.ContainerAutoscalingPolicy{
+							{
+								ContainerName: "app",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
isMonitorVPAReady now correctly checks that the VPA has recommendations for at least Tortoise defined containers, extra containers doesn't result in a false not ready.

<!--  
Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/

Also, please read the contributor guide, which contains some general rules and suggestions:
https://github.com/mercari/tortoise/blob/main/docs/contributor-guide.md
-->

#### What this PR does / why we need it:

Changes the comparison in isMonitorVPAReady to behave as expected when there are more containers in the VPA/Pod than defined in the Tortoise object.

#### Which issue(s) this PR fixes:

Fixes #413 
<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

#### Special notes for your reviewer:
