### PR TITLE
Add labelsEffectiveness metrics

### DIFF
--- a/pkg/hpa/service.go
+++ b/pkg/hpa/service.go
@@ -417,6 +417,8 @@ func (c *Service) ChangeHPAFromTortoiseRecommendation(tortoise *autoscalingv1bet
 	}
 
 	if recordMetrics {
+		metrics.NetHPAMinReplicas.WithLabelValues(tortoise.Name, tortoise.Namespace, hpa.Name).Set(float64(*hpa.Spec.MinReplicas) - float64(recommendMin))
+		metrics.NetHPAMaxReplicas.WithLabelValues(tortoise.Name, tortoise.Namespace, hpa.Name).Set(float64(hpa.Spec.MaxReplicas - recommendMax))
 		metrics.ProposedHPAMinReplicas.WithLabelValues(tortoise.Name, tortoise.Namespace, hpa.Name).Set(float64(recommendMin))
 		metrics.ProposedHPAMaxReplicas.WithLabelValues(tortoise.Name, tortoise.Namespace, hpa.Name).Set(float64(recommendMax))
 	}

--- a/pkg/hpa/service.go
+++ b/pkg/hpa/service.go
@@ -454,8 +454,8 @@ func (c *Service) ChangeHPAFromTortoiseRecommendation(tortoise *autoscalingv1bet
 		if netChangeMaxReplicas < 0 || netChangeMinReplicas > 0 {
 			metrics.DecreaseApplyCounter.WithLabelValues(tortoise.Name, tortoise.Namespace).Add(1)
 		}
-		metrics.NetHPAMinReplicas.WithLabelValues(tortoise.Name, tortoise.Namespace, hpa.Name).Set(netChangeMinReplicas)
-		metrics.NetHPAMaxReplicas.WithLabelValues(tortoise.Name, tortoise.Namespace, hpa.Name).Set(netChangeMaxReplicas)
+		metrics.NetHPAMinReplicas.WithLabelValues(tortoise.Name, tortoise.Namespace, hpa.Name, tortoise.Spec.TargetRefs.ScaleTargetRef.Name).Set(netChangeMinReplicas)
+		metrics.NetHPAMaxReplicas.WithLabelValues(tortoise.Name, tortoise.Namespace, hpa.Name, tortoise.Spec.TargetRefs.ScaleTargetRef.Name).Set(netChangeMaxReplicas)
 		metrics.AppliedHPAMinReplicas.WithLabelValues(tortoise.Name, tortoise.Namespace, hpa.Name).Set(float64(*hpa.Spec.MinReplicas))
 		metrics.AppliedHPAMaxReplicas.WithLabelValues(tortoise.Name, tortoise.Namespace, hpa.Name).Set(float64(hpa.Spec.MaxReplicas))
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -118,7 +118,7 @@ func init() {
 		AppliedCPURequest,
 		AppliedMemoryRequest,
 		IncreaseApplyCounter,
-		DecreaseApplyCounter
+		DecreaseApplyCounter,
 		NetHPAMaxReplicas,
 		NetHPAMinReplicas,
 		NetCPURequest,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -46,6 +46,16 @@ var (
 		Help: "memory request (byte) that tortoises actually applys",
 	}, []string{"tortoise_name", "namespace", "container_name", "controller_name", "controller_kind"})
 
+	DecreaseApplyCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "decrease_apply_counter",
+		Help: "counter for number of resource decreases applied by tortoise",
+	}, []string{"tortoise_name", "namespace"})
+
+	IncreaseApplyCounter = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "increase_apply_counter",
+		Help: "counter for number of resource increases applied by tortoise",
+	}, []string{"tortoise_name", "namespace"})
+
 	NetHPAMinReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "net_hpa_minreplicas",
 		Help: "net hpa minReplicas that tortoises actually applys to hpa",
@@ -107,6 +117,12 @@ func init() {
 		AppliedHPAMinReplicas,
 		AppliedCPURequest,
 		AppliedMemoryRequest,
+		IncreaseApplyCounter,
+		DecreaseApplyCounter
+		NetHPAMaxReplicas,
+		NetHPAMinReplicas,
+		NetCPURequest,
+		NetMemoryRequest,
 		ProposedHPATargetUtilization,
 		ProposedHPAMinReplicas,
 		ProposedHPAMaxReplicas,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -46,6 +46,26 @@ var (
 		Help: "memory request (byte) that tortoises actually applys",
 	}, []string{"tortoise_name", "namespace", "container_name", "controller_name", "controller_kind"})
 
+	NetHPAMinReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "net_hpa_minreplicas",
+		Help: "net hpa minReplicas that tortoises actually applys to hpa",
+	}, []string{"tortoise_name", "namespace", "hpa_name"})
+
+	NetHPAMaxReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "net_hpa_maxreplicas",
+		Help: "net hpa maxReplicas that tortoises actually applys to hpa",
+	}, []string{"tortoise_name", "namespace", "hpa_name"})
+
+	NetCPURequest = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "net_cpu_request",
+		Help: "net cpu request (millicore) that tortoises actually applys",
+	}, []string{"tortoise_name", "namespace", "container_name", "controller_name", "controller_kind"})
+
+	NetMemoryRequest = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "net_memory_request",
+		Help: "net memory request (byte) that tortoises actually applys",
+	}, []string{"tortoise_name", "namespace", "container_name", "controller_name", "controller_kind"})
+
 	ProposedHPATargetUtilization = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "proposed_hpa_utilization_target",
 		Help: "recommended hpa utilization target values that tortoises propose",

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -59,12 +59,12 @@ var (
 	NetHPAMinReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "net_hpa_minreplicas",
 		Help: "net hpa minReplicas that tortoises actually applys to hpa",
-	}, []string{"tortoise_name", "namespace", "hpa_name"})
+	}, []string{"tortoise_name", "namespace", "hpa_name", "kube_deployment"})
 
 	NetHPAMaxReplicas = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "net_hpa_maxreplicas",
 		Help: "net hpa maxReplicas that tortoises actually applys to hpa",
-	}, []string{"tortoise_name", "namespace", "hpa_name"})
+	}, []string{"tortoise_name", "namespace", "hpa_name", "kube_deployment"})
 
 	NetCPURequest = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "net_cpu_request",


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!  
Please read the CLA carefully before submitting your contribution to Mercari. 
Under any circumstances, by submitting your contribution, you are deemed to accept and agree to be bound by the terms and conditions of the CLA.
https://www.mercari.com/cla/

Also, please read the contributor guide, which contains some general rules and suggestions:
https://github.com/mercari/tortoise/blob/main/docs/contributor-guide.md
-->

#### What this PR does / why we need it:
Net replicas for HPA needs to be calculated with container requests in order to determine savings but since there are no common labels it cannot be calculated in datadog. This PR adds kube_deployment label to net replica metrics

#### Which issue(s) this PR fixes:

<!--
Before implementing any feature changes, please raise the issue and discuss what you propose with maintainers.
-->

Fixes #

#### Special notes for your reviewer:
