### PR TITLE
enable tortoise to move to Working from BackToNormal when there is no HPA

### DIFF
--- a/pkg/tortoise/tortoise.go
+++ b/pkg/tortoise/tortoise.go
@@ -135,6 +135,13 @@ func (s *Service) UpdateTortoisePhase(tortoise *v1beta3.Tortoise, now time.Time)
 			s.recorder.Event(tortoise, corev1.EventTypeNormal, event.Working, "Emergency mode is turned off. Tortoise starts to work on autoscaling normally. HPA.Spec.MinReplica will gradually be reduced")
 			tortoise.Status.TortoisePhase = v1beta3.TortoisePhaseBackToNormal
 		}
+	case v1beta3.TortoisePhaseBackToNormal:
+		if !hasHorizontal(tortoise) {
+			// If there's no HPA, we can transition directly to Working
+			tortoise.Status.TortoisePhase = v1beta3.TortoisePhaseWorking
+			s.recorder.Event(tortoise, corev1.EventTypeNormal, event.Working, "Tortoise has no horizontal scaling, transitioning directly to Working phase")
+		}
+		// If there is HPA, let the HPA service handle the transition
 	}
 
 	if tortoise.Spec.UpdateMode == v1beta3.UpdateModeEmergency {


### PR DESCRIPTION
Issue: https://github.com/mercari/tortoise/issues/444

What:
- adds logic for Tortoise to move from `BackToNormal` to `Working` so that new recommendations can be applied
- also adds test cases to test this change and well as existing phase changes

Why:
- we observed in all vertical//VPA cases, tortoise when in `BackToNormal` phase i.e after switching from `Emergency` Mode would continue to stay in `BacktoNormal` due to the fact that the existing logic at [line](https://github.com/mercari/tortoise/blob/2016be57607a19bc07871d28c64535fd2da200c8/pkg/hpa/service.go#L452) would execute only when there is a corresponding HPA which is evident from this [line](https://github.com/mercari/tortoise/blob/2016be57607a19bc07871d28c64535fd2da200c8/pkg/hpa/service.go#L608). 
- so for cases when it is all VPA, we handle the case to switch the above phase outside of the HPA service in the tortoise service itself.     