### PR TITLE
Use ubuntu-lates runner as ubuntu-20 is discontinued

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-tortoise:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check out code into the Go module directory


### PR DESCRIPTION
Issue: https://github.com/mercari/tortoise/actions/runs/15130655439/job/42531420525

Why: https://github.com/actions/runner-images/issues/11101 
Ubuntu-20.04 runner is dicontinued and workflows using them will be cancelled automatically