### PR TITLE
Fix bug when tortoise is in OFF and HPA has external dg metric

### DIFF
--- a/internal/controller/testdata/reconcile-automatic-emergency-mode-hpa-back-to-working/after/hpa.yaml
+++ b/internal/controller/testdata/reconcile-automatic-emergency-mode-hpa-back-to-working/after/hpa.yaml
@@ -53,8 +53,10 @@ status:
         name: cpu
         current:
           value: 3
+      type: ContainerResource
     - containerResource:
         container: istio-proxy
         name: cpu
         current:
           value: 3
+      type: ContainerResource

--- a/internal/controller/testdata/reconcile-automatic-emergency-mode-hpa-back-to-working/before/hpa.yaml
+++ b/internal/controller/testdata/reconcile-automatic-emergency-mode-hpa-back-to-working/before/hpa.yaml
@@ -17,11 +17,13 @@ status:
         name: cpu
         current:
           value: 3
+      type: ContainerResource
     - containerResource:
         container: istio-proxy
         name: cpu
         current:
           value: 3
+      type: ContainerResource
 spec:
   behavior:
     scaleDown:

--- a/internal/controller/testdata/reconcile-automatic-emergency-mode-mixed-policies-healthy/after/hpa.yaml
+++ b/internal/controller/testdata/reconcile-automatic-emergency-mode-mixed-policies-healthy/after/hpa.yaml
@@ -53,8 +53,10 @@ status:
         name: cpu
         current:
           value: 4
+      type: ContainerResource
     - containerResource:
         container: istio-proxy
         name: cpu
         current:
           value: 1
+      type: ContainerResource

--- a/internal/controller/testdata/reconcile-automatic-emergency-mode-mixed-policies-healthy/before/hpa.yaml
+++ b/internal/controller/testdata/reconcile-automatic-emergency-mode-mixed-policies-healthy/before/hpa.yaml
@@ -17,11 +17,13 @@ status:
         name: cpu
         current:
           value: 4
+      type: ContainerResource
     - containerResource:
         container: istio-proxy
         name: cpu
         current:
           value: 1
+      type: ContainerResource
 spec:
   behavior:
     scaleDown:

--- a/pkg/hpa/service_test.go
+++ b/pkg/hpa/service_test.go
@@ -5087,6 +5087,166 @@ func TestService_IsHpaMetricAvailable(t *testing.T) {
 			},
 			result: true,
 		},
+		{
+			name:     "HPA with non-zero external metric and non-zero container metric, should return true",
+			Tortoise: commonTortoise,
+			HPA: &v2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hpa",
+					Namespace: "default",
+				},
+				Status: v2.HorizontalPodAutoscalerStatus{
+					Conditions: []v2.HorizontalPodAutoscalerCondition{
+						{
+							Type:   "ScalingActive",
+							Status: "True",
+						},
+					},
+					CurrentMetrics: []v2.MetricStatus{
+						{
+							Type: "External",
+							External: &v2.ExternalMetricStatus{
+								Current: v2.MetricValueStatus{
+									Value: resource.NewQuantity(500, resource.DecimalSI),
+								},
+							},
+						},
+						{
+							Type: "ContainerResource",
+							ContainerResource: &v2.ContainerResourceMetricStatus{
+								Container: "app",
+								Current: v2.MetricValueStatus{
+									AverageUtilization: ptr.To[int32](50),
+									AverageValue:       resource.NewQuantity(1, resource.DecimalSI),
+									Value:              resource.NewQuantity(1, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+			},
+			result: true,
+		},
+		{
+			name:     "HPA with zero external metric and non-zero container metric, should return true",
+			Tortoise: commonTortoise,
+			HPA: &v2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hpa",
+					Namespace: "default",
+				},
+				Status: v2.HorizontalPodAutoscalerStatus{
+					Conditions: []v2.HorizontalPodAutoscalerCondition{
+						{
+							Type:   "ScalingActive",
+							Status: "True",
+						},
+					},
+					CurrentMetrics: []v2.MetricStatus{
+						{
+							Type: "External",
+							External: &v2.ExternalMetricStatus{
+								Current: v2.MetricValueStatus{
+									Value: resource.NewQuantity(0, resource.DecimalSI),
+								},
+							},
+						},
+						{
+							Type: "ContainerResource",
+							ContainerResource: &v2.ContainerResourceMetricStatus{
+								Container: "app",
+								Current: v2.MetricValueStatus{
+									AverageUtilization: ptr.To[int32](50),
+									AverageValue:       resource.NewQuantity(1, resource.DecimalSI),
+									Value:              resource.NewQuantity(1, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+			},
+			result: true,
+		},
+		{
+			name:     "HPA with non-zero external metric and zero container metric, should return true",
+			Tortoise: commonTortoise,
+			HPA: &v2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hpa",
+					Namespace: "default",
+				},
+				Status: v2.HorizontalPodAutoscalerStatus{
+					Conditions: []v2.HorizontalPodAutoscalerCondition{
+						{
+							Type:   "ScalingActive",
+							Status: "True",
+						},
+					},
+					CurrentMetrics: []v2.MetricStatus{
+						{
+							Type: "External",
+							External: &v2.ExternalMetricStatus{
+								Current: v2.MetricValueStatus{
+									Value: resource.NewQuantity(500, resource.DecimalSI),
+								},
+							},
+						},
+						{
+							Type: "ContainerResource",
+							ContainerResource: &v2.ContainerResourceMetricStatus{
+								Container: "app",
+								Current: v2.MetricValueStatus{
+									AverageUtilization: ptr.To[int32](0),
+									AverageValue:       resource.NewQuantity(0, resource.DecimalSI),
+									Value:              resource.NewQuantity(0, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+			},
+			result: true,
+		},
+		{
+			name:     "HPA with zero external metric and zero container metric, should return false",
+			Tortoise: commonTortoise,
+			HPA: &v2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hpa",
+					Namespace: "default",
+				},
+				Status: v2.HorizontalPodAutoscalerStatus{
+					Conditions: []v2.HorizontalPodAutoscalerCondition{
+						{
+							Type:   "ScalingActive",
+							Status: "True",
+						},
+					},
+					CurrentMetrics: []v2.MetricStatus{
+						{
+							Type: "External",
+							External: &v2.ExternalMetricStatus{
+								Current: v2.MetricValueStatus{
+									Value: resource.NewQuantity(0, resource.DecimalSI),
+								},
+							},
+						},
+						{
+							Type: "ContainerResource",
+							ContainerResource: &v2.ContainerResourceMetricStatus{
+								Container: "app",
+								Current: v2.MetricValueStatus{
+									AverageUtilization: ptr.To[int32](0),
+									AverageValue:       resource.NewQuantity(0, resource.DecimalSI),
+									Value:              resource.NewQuantity(0, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+			},
+			result: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
WHY

When tortoise is in `off` and hpa contains other types of metric like `external` we observed `panic` error in the controller code due to the way it was handled in the code without a null check.

WHAT

Adds a null check for the containerMetric type and also adds suppport for `external` type of contaienerResoruce 