### PR TITLE
Fix/kustomize issues 435 440

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,16 @@ testbin/*
 
 !vendor/**/zz_generated.*
 
+# Generated installation files
+dist/
+
 # editor and IDE paraphernalia
 .idea
 *.swp
 *.swo
 *~
+
+# Claude code related ignores
+.claude-helper
+claude-helper
+project-state.md

--- a/Makefile
+++ b/Makefile
@@ -139,8 +139,15 @@ ifndef ignore-not-found
   ignore-not-found = false
 endif
 
+.PHONY: validate-kustomize
+validate-kustomize: kustomize ## Validate kustomization files syntax
+	@echo "Validating kustomization files..."
+	$(KUSTOMIZE) build config/crd > /dev/null
+	$(KUSTOMIZE) build config/default > /dev/null
+	@echo "Kustomization files are valid"
+
 .PHONY: install
-install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
+install: manifests kustomize validate-kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) apply -f -
 
 .PHONY: uninstall
@@ -148,7 +155,7 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | $(KUBECTL) delete --ignore-not-found=$(ignore-not-found) -f -
 
 .PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
+deploy: manifests kustomize validate-kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default | $(KUBECTL) apply -f -
 

--- a/config/certmanager/kustomization.yaml
+++ b/config/certmanager/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - certificate.yaml
 

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 # This kustomization.yaml is not intended to be run by itself,
 # since it depends on service name and namespace that are out of this kustomize package.
 # It should be run by config/default
@@ -9,8 +12,6 @@ resources:
 configurations:
 - kustomizeconfig.yaml
 
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
 patches:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 # Adds namespace to all resources.
 namespace: tortoise-system
 
@@ -12,7 +15,7 @@ namePrefix: tortoise-
 #commonLabels:
 #  someName: someValue
 
-bases:
+resources:
 - ../crd
 - ../rbac
 - ../manager
@@ -22,47 +25,76 @@ bases:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
-patchesStrategicMerge:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- path: manager_auth_proxy_patch.yaml
 
 # Mount the controller config file for loading manager configurations
 # through a ComponentConfig type
 #- manager_config_patch.yaml
 
+
+# the following config is for teaching kustomize how to do replacements
+replacements:
+- source:
+    fieldPath: .metadata.namespace
+    group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
+    version: v1
+  targets:
+  - fieldPaths:
+    - .webhooks.[name=tortoise-validating-webhook].clientConfig.service.namespace
+    select:
+      kind: ValidatingAdmissionWebhook
+  - fieldPaths:
+    - .webhooks.[name=tortoise-mutating-webhook].clientConfig.service.namespace
+    select:
+      kind: MutatingAdmissionWebhook
+- source:
+    fieldPath: .metadata.name
+    group: cert-manager.io
+    kind: Certificate
+    name: serving-cert
+    version: v1
+  targets:
+  - fieldPaths:
+    - .webhooks.[name=tortoise-validating-webhook].clientConfig.service.name
+    select:
+      kind: ValidatingAdmissionWebhook
+  - fieldPaths:
+    - .webhooks.[name=tortoise-mutating-webhook].clientConfig.service.name
+    select:
+      kind: MutatingAdmissionWebhook
+- source:
+    fieldPath: .metadata.namespace
+    kind: Service
+    name: webhook-service
+    version: v1
+  targets:
+  - fieldPaths:
+    - .webhooks.[name=tortoise-validating-webhook].clientConfig.service.namespace
+    select:
+      kind: ValidatingAdmissionWebhook
+  - fieldPaths:
+    - .webhooks.[name=tortoise-mutating-webhook].clientConfig.service.namespace
+    select:
+      kind: MutatingAdmissionWebhook
+- source:
+    fieldPath: .metadata.name
+    kind: Service
+    name: webhook-service
+    version: v1
+  targets:
+  - fieldPaths:
+    - .webhooks.[name=tortoise-validating-webhook].clientConfig.service.name
+    select:
+      kind: ValidatingAdmissionWebhook
+  - fieldPaths:
+    - .webhooks.[name=tortoise-mutating-webhook].clientConfig.service.name
+    select:
+      kind: MutatingAdmissionWebhook
+patches:
+- path: manager_auth_proxy_patch.yaml
 - path: manager_webhook_patch.yaml
 - path: webhookcainjection_patch.yaml
-- path: manager_metrics_patch.yaml
-  target:
-    kind: Deployment
-
-# the following config is for teaching kustomize how to do var substitution
-vars:
-- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-  objref:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-  fieldref:
-    fieldpath: metadata.namespace
-- name: CERTIFICATE_NAME
-  objref:
-    kind: Certificate
-    group: cert-manager.io
-    version: v1
-    name: serving-cert # this name should match the one in certificate.yaml
-- name: SERVICE_NAMESPACE # namespace of the service
-  objref:
-    kind: Service
-    version: v1
-    name: webhook-service
-  fieldref:
-    fieldpath: metadata.namespace
-- name: SERVICE_NAME
-  objref:
-    kind: Service
-    version: v1
-    name: webhook-service

--- a/config/default/metrics_service.yaml
+++ b/config/default/metrics_service.yaml
@@ -5,7 +5,7 @@ metadata:
     control-plane: controller-manager
     app.kubernetes.io/name: tortoise
     app.kubernetes.io/managed-by: kustomize
-  name: controller-manager-metrics-service
+  name: tortoise-metrics-service
   namespace: system
 spec:
   ports:

--- a/config/prometheus/kustomization.yaml
+++ b/config/prometheus/kustomization.yaml
@@ -1,2 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - monitor.yaml

--- a/config/rbac/kustomization.yaml
+++ b/config/rbac/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 # All RBAC will be applied under this service account in
 # the deployment namespace. You may comment out this resource

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,3 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
 resources:
 - manifests.yaml
 - service.yaml


### PR DESCRIPTION
Summary

This PR aims to fix issues #435 and #440

✅ Key Fixes Applied:

1. Fixed deprecated syntax in all kustomization.yaml files:
    - Removed path: prefix from patchesStrategicMerge entries
    - Added proper apiVersion: kustomize.config.k8s.io/v1beta1 and kind: Kustomization headers
    - Updated bases: to resources: in default kustomization
2. Resolved service name conflicts:
    - Renamed controller-manager-metrics-service to tortoise-metrics-service in config/default/metrics_service.yaml to avoid collision with RBAC proxy service
3. Updated deprecated vars to replacements:
    - Converted the old vars section to modern replacements syntax for webhook configuration
    - Applied kustomize edit fix to automatically convert deprecated patchesStrategicMerge to patches
4. Removed missing file references:
    - Eliminated reference to non-existent manager_metrics_patch.yaml
5. Added validation to Makefile:
    - Created new validate-kustomize target that validates syntax before deployment
    - Updated install and deploy targets to include validation step

✅ Files Modified:

- Makefile - Added validation targets
- config/default/kustomization.yaml - Major syntax updates and replacements conversion
- config/default/metrics_service.yaml - Renamed service to avoid conflicts
- All other config/*/kustomization.yaml files - Added proper headers and fixed syntax
