### PR TITLE
Add grace period before entering into Emergency mode

### DIFF
--- a/api/autoscaling/v2/webhook_suite_test.go
+++ b/api/autoscaling/v2/webhook_suite_test.go
@@ -168,7 +168,7 @@ var _ = BeforeSuite(func() {
 	eventRecorder := mgr.GetEventRecorderFor("tortoise-controller")
 	tortoiseService, err := tortoise.New(mgr.GetClient(), eventRecorder, config.RangeOfMinMaxReplicasRecommendationHours, config.TimeZone, config.TortoiseUpdateInterval, config.GatheringDataPeriodType)
 	Expect(err).NotTo(HaveOccurred())
-	hpaService, err := hpa.New(mgr.GetClient(), eventRecorder, config.ReplicaReductionFactor, config.MaximumTargetResourceUtilization, 100, time.Hour, nil, 1000, 10000, 3, "")
+	hpaService, err := hpa.New(mgr.GetClient(), eventRecorder, config.ReplicaReductionFactor, config.MaximumTargetResourceUtilization, 100, time.Hour, nil, 1000, 10000, 3, "", 5*time.Minute)
 	Expect(err).NotTo(HaveOccurred())
 
 	hpaWebhook := New(tortoiseService, hpaService)

--- a/api/autoscaling/v2/webhook_suite_test.go
+++ b/api/autoscaling/v2/webhook_suite_test.go
@@ -168,7 +168,7 @@ var _ = BeforeSuite(func() {
 	eventRecorder := mgr.GetEventRecorderFor("tortoise-controller")
 	tortoiseService, err := tortoise.New(mgr.GetClient(), eventRecorder, config.RangeOfMinMaxReplicasRecommendationHours, config.TimeZone, config.TortoiseUpdateInterval, config.GatheringDataPeriodType)
 	Expect(err).NotTo(HaveOccurred())
-	hpaService, err := hpa.New(mgr.GetClient(), eventRecorder, config.ReplicaReductionFactor, config.MaximumTargetResourceUtilization, 100, time.Hour, nil, 1000, 10000, 3, "", 5*time.Minute)
+	hpaService, err := hpa.New(mgr.GetClient(), eventRecorder, config.ReplicaReductionFactor, config.MaximumTargetResourceUtilization, 100, time.Hour, nil, 1000, 10000, 3, "", config.EmergencyModeGracePeriod)
 	Expect(err).NotTo(HaveOccurred())
 
 	hpaWebhook := New(tortoiseService, hpaService)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -152,7 +152,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	hpaService, err := hpa.New(mgr.GetClient(), eventRecorder, config.ReplicaReductionFactor, config.MaximumTargetResourceUtilization, config.HPATargetUtilizationMaxIncrease, config.HPATargetUtilizationUpdateInterval, config.DefaultHPABehavior, config.MaximumMinReplicas, config.MaximumMaxReplicas, int32(config.MinimumMinReplicas), config.HPAExternalMetricExclusionRegex, 5*time.Minute)
+	hpaService, err := hpa.New(mgr.GetClient(), eventRecorder, config.ReplicaReductionFactor, config.MaximumTargetResourceUtilization, config.HPATargetUtilizationMaxIncrease, config.HPATargetUtilizationUpdateInterval, config.DefaultHPABehavior, config.MaximumMinReplicas, config.MaximumMaxReplicas, int32(config.MinimumMinReplicas), config.HPAExternalMetricExclusionRegex, config.EmergencyModeGracePeriod)
 	if err != nil {
 		setupLog.Error(err, "unable to start hpa service")
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -152,7 +152,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	hpaService, err := hpa.New(mgr.GetClient(), eventRecorder, config.ReplicaReductionFactor, config.MaximumTargetResourceUtilization, config.HPATargetUtilizationMaxIncrease, config.HPATargetUtilizationUpdateInterval, config.DefaultHPABehavior, config.MaximumMinReplicas, config.MaximumMaxReplicas, int32(config.MinimumMinReplicas), config.HPAExternalMetricExclusionRegex)
+	hpaService, err := hpa.New(mgr.GetClient(), eventRecorder, config.ReplicaReductionFactor, config.MaximumTargetResourceUtilization, config.HPATargetUtilizationMaxIncrease, config.HPATargetUtilizationUpdateInterval, config.DefaultHPABehavior, config.MaximumMinReplicas, config.MaximumMaxReplicas, int32(config.MinimumMinReplicas), config.HPAExternalMetricExclusionRegex, 5*time.Minute)
 	if err != nil {
 		setupLog.Error(err, "unable to start hpa service")
 		os.Exit(1)

--- a/internal/controller/tortoise_controller_test.go
+++ b/internal/controller/tortoise_controller_test.go
@@ -259,7 +259,7 @@ func startController(ctx context.Context) func() {
 	Expect(err).ShouldNot(HaveOccurred())
 	cli, err := vpa.New(mgr.GetConfig(), recorder)
 	Expect(err).ShouldNot(HaveOccurred())
-	hpaS, err := hpa.New(mgr.GetClient(), recorder, 0.95, 90, 25, time.Hour, nil, 1000, 10000, 3, ".*-exclude-metric")
+	hpaS, err := hpa.New(mgr.GetClient(), recorder, 0.95, 90, 25, time.Hour, nil, 1000, 10000, 3, ".*-exclude-metric", 5*time.Minute)
 	Expect(err).ShouldNot(HaveOccurred())
 	reconciler := &TortoiseReconciler{
 		Scheme:             scheme,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -236,6 +236,11 @@ type Config struct {
 	// all the external metric which name matches `datadogmetric.*` regex are removed by Tortoise once Tortoise is in Auto mode.
 	HPAExternalMetricExclusionRegex string `yaml:"HPAExternalMetricExclusionRegex"`
 
+	// EmergencyModeGracePeriod is the grace period before triggering emergency mode when HPA metrics are temporarily unavailable (default: 5m)
+	// This prevents false emergency mode triggers during temporary HPA metric unavailability during HPA updates, deployments, scheduled scaling, etc.
+	// During this grace period, the system will continue normal operation even if HPA metrics are temporarily unavailable.
+	EmergencyModeGracePeriod time.Duration `yaml:"EmergencyModeGracePeriod"`
+
 	// DefaultHPABehavior defines the default behavior for HPAs created and managed by Tortoise.
 	// If not specified, Tortoise will use built-in default values that scale up aggressively and scale down conservatively.
 	// This default behavior will be used when individual Tortoise resources don't specify their own behavior.
@@ -319,6 +324,7 @@ func defaultConfig() *Config {
 		MinimumCPULimit:                          "0",
 		ResourceLimitMultiplier:                  map[string]int64{},
 		BufferRatioOnVerticalResource:            0.1,
+		EmergencyModeGracePeriod:                 5 * time.Minute,
 	}
 }
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -61,6 +61,7 @@ func TestParseConfig(t *testing.T) {
 					"memory": 1,
 				},
 				BufferRatioOnVerticalResource: 0.2,
+				EmergencyModeGracePeriod:      5 * time.Minute,
 			},
 		},
 		{
@@ -96,6 +97,7 @@ func TestParseConfig(t *testing.T) {
 				MinimumMemoryRequestPerContainer:         map[string]string{},
 				ResourceLimitMultiplier:                  map[string]int64{},
 				BufferRatioOnVerticalResource:            0.1,
+				EmergencyModeGracePeriod:                 5 * time.Minute,
 			},
 		},
 		{
@@ -138,6 +140,7 @@ func TestParseConfig(t *testing.T) {
 				MinimumMemoryRequestPerContainer:         map[string]string{},
 				ResourceLimitMultiplier:                  map[string]int64{},
 				BufferRatioOnVerticalResource:            0.1,
+				EmergencyModeGracePeriod:                 5 * time.Minute,
 			},
 		},
 	}

--- a/pkg/hpa/service.go
+++ b/pkg/hpa/service.go
@@ -94,11 +94,7 @@ func New(
 		defaultHPABehavior = defaultHPABehaviorValue
 	}
 
-	// Default emergency mode grace period if not provided
 	// This prevents false emergency mode triggers during temporary HPA metric unavailability
-	if emergencyModeGracePeriod == 0 {
-		emergencyModeGracePeriod = 5 * time.Minute
-	}
 
 	return &Service{
 		c:                                       c,
@@ -819,7 +815,7 @@ func (c *Service) IsHpaMetricAvailable(ctx context.Context, tortoise *autoscalin
 			// metric unavailability during HPA updates, deployments, scheduled scaling, etc.
 			conditionAge := time.Since(condition.LastTransitionTime.Time)
 			if conditionAge < c.emergencyModeGracePeriod {
-				logger.Info("HPA metric temporarily unavailable, giving grace time before emergency mode",
+				logger.V(1).Info("HPA metric temporarily unavailable, giving grace time before emergency mode",
 					"gracePeriod", c.emergencyModeGracePeriod,
 					"conditionAge", conditionAge)
 				return true // Give grace period before emergency mode

--- a/pkg/hpa/service_test.go
+++ b/pkg/hpa/service_test.go
@@ -2750,7 +2750,7 @@ func TestClient_UpdateHPAFromTortoiseRecommendation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := New(fake.NewClientBuilder().WithRuntimeObjects(tt.initialHPA).Build(), record.NewFakeRecorder(10), 0.95, 90, 50, time.Hour, nil, 1000, 10001, 3, tt.excludeMetricRegex)
+			c, err := New(fake.NewClientBuilder().WithRuntimeObjects(tt.initialHPA).Build(), record.NewFakeRecorder(10), 0.95, 90, 50, time.Hour, nil, 1000, 10001, 3, tt.excludeMetricRegex, 5*time.Minute)
 			if err != nil {
 				t.Fatalf("New() error = %v", err)
 			}
@@ -3063,12 +3063,12 @@ func TestService_InitializeHPA(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := New(fake.NewClientBuilder().Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 100, 1000, 3, "")
+			c, err := New(fake.NewClientBuilder().Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 100, 1000, 3, "", 5*time.Minute)
 			if err != nil {
 				t.Fatalf("New() error = %v", err)
 			}
 			if tt.initialHPA != nil {
-				c, err = New(fake.NewClientBuilder().WithRuntimeObjects(tt.initialHPA).Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 100, 1000, 3, "")
+				c, err = New(fake.NewClientBuilder().WithRuntimeObjects(tt.initialHPA).Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 100, 1000, 3, "", 5*time.Minute)
 				if err != nil {
 					t.Fatalf("New() error = %v", err)
 				}
@@ -4621,12 +4621,12 @@ func TestService_UpdateHPASpecFromTortoiseAutoscalingPolicy(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := New(fake.NewClientBuilder().Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 1000, 10000, 3, "")
+			c, err := New(fake.NewClientBuilder().Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 1000, 10000, 3, "", 5*time.Minute)
 			if err != nil {
 				t.Fatalf("New() error = %v", err)
 			}
 			if tt.initialHPA != nil {
-				c, err = New(fake.NewClientBuilder().WithRuntimeObjects(tt.initialHPA).Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 1000, 10000, 3, "")
+				c, err = New(fake.NewClientBuilder().WithRuntimeObjects(tt.initialHPA).Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 1000, 10000, 3, "", 5*time.Minute)
 				if err != nil {
 					t.Fatalf("New() error = %v", err)
 				}
@@ -5250,7 +5250,7 @@ func TestService_IsHpaMetricAvailable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := New(fake.NewClientBuilder().Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 100, 1000, 3, "")
+			c, err := New(fake.NewClientBuilder().Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 100, 1000, 3, "", 5*time.Minute)
 			if err != nil {
 				t.Fatalf("New() error = %v", err)
 			}
@@ -5258,6 +5258,261 @@ func TestService_IsHpaMetricAvailable(t *testing.T) {
 			if status != tt.result {
 				t.Errorf("Service.checkHpaMetricStatus() status test: %s failed", tt.name)
 				return
+			}
+		})
+	}
+}
+
+func TestService_IsHpaMetricAvailable_EmergencyModeGracePeriod(t *testing.T) {
+	now := time.Now()
+
+	// Tortoise with horizontal scaling policy
+	horizontalTortoise := &v1beta3.Tortoise{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-tortoise",
+			Namespace: "default",
+		},
+		Status: v1beta3.TortoiseStatus{
+			AutoscalingPolicy: []v1beta3.ContainerAutoscalingPolicy{
+				{
+					ContainerName: "app",
+					Policy: map[v1.ResourceName]v1beta3.AutoscalingType{
+						v1.ResourceCPU: v1beta3.AutoscalingTypeHorizontal,
+					},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name                     string
+		tortoise                 *v1beta3.Tortoise
+		hpa                      *v2.HorizontalPodAutoscaler
+		emergencyModeGracePeriod time.Duration
+		expected                 bool
+		description              string
+	}{
+		{
+			name:     "Grace period active - recent failure should not trigger emergency mode",
+			tortoise: horizontalTortoise,
+			hpa: &v2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hpa",
+					Namespace: "default",
+				},
+				Status: v2.HorizontalPodAutoscalerStatus{
+					Conditions: []v2.HorizontalPodAutoscalerCondition{
+						{
+							Type:               v2.ScalingActive,
+							Status:             "False",
+							Reason:             "FailedGetResourceMetric",
+							Message:            "failed to get cpu utilization: unable to fetch metrics from resource metrics API",
+							LastTransitionTime: metav1.NewTime(now.Add(-2 * time.Minute)), // Recent failure
+						},
+					},
+					CurrentMetrics: []v2.MetricStatus{
+						{
+							Type: "ContainerResource",
+							ContainerResource: &v2.ContainerResourceMetricStatus{
+								Container: "app",
+								Name:      v1.ResourceCPU,
+								Current: v2.MetricValueStatus{
+									AverageUtilization: ptr.To[int32](0),
+									AverageValue:       resource.NewQuantity(0, resource.DecimalSI),
+									Value:              resource.NewQuantity(0, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+			},
+			emergencyModeGracePeriod: 5 * time.Minute, // Grace period longer than failure time
+			expected:                 true,            // Should NOT trigger emergency mode
+			description:              "Recent failure within grace period should return true (no emergency)",
+		},
+		{
+			name:     "Grace period expired - old failure should trigger emergency mode",
+			tortoise: horizontalTortoise,
+			hpa: &v2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hpa",
+					Namespace: "default",
+				},
+				Status: v2.HorizontalPodAutoscalerStatus{
+					Conditions: []v2.HorizontalPodAutoscalerCondition{
+						{
+							Type:               v2.ScalingActive,
+							Status:             "False",
+							Reason:             "FailedGetResourceMetric",
+							Message:            "failed to get cpu utilization: unable to fetch metrics from resource metrics API",
+							LastTransitionTime: metav1.NewTime(now.Add(-10 * time.Minute)), // Old failure
+						},
+					},
+					CurrentMetrics: []v2.MetricStatus{
+						{
+							Type: "ContainerResource",
+							ContainerResource: &v2.ContainerResourceMetricStatus{
+								Container: "app",
+								Name:      v1.ResourceCPU,
+								Current: v2.MetricValueStatus{
+									AverageUtilization: ptr.To[int32](0),
+									AverageValue:       resource.NewQuantity(0, resource.DecimalSI),
+									Value:              resource.NewQuantity(0, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+			},
+			emergencyModeGracePeriod: 5 * time.Minute, // Grace period shorter than failure time
+			expected:                 false,           // Should trigger emergency mode
+			description:              "Old failure beyond grace period should return false (trigger emergency)",
+		},
+		{
+			name:     "Short grace period - should trigger emergency mode quickly",
+			tortoise: horizontalTortoise,
+			hpa: &v2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hpa",
+					Namespace: "default",
+				},
+				Status: v2.HorizontalPodAutoscalerStatus{
+					Conditions: []v2.HorizontalPodAutoscalerCondition{
+						{
+							Type:               v2.ScalingActive,
+							Status:             "False",
+							Reason:             "FailedGetResourceMetric",
+							Message:            "failed to get cpu utilization",
+							LastTransitionTime: metav1.NewTime(now.Add(-2 * time.Minute)), // 2 minutes ago
+						},
+					},
+					CurrentMetrics: []v2.MetricStatus{
+						{
+							Type: "ContainerResource",
+							ContainerResource: &v2.ContainerResourceMetricStatus{
+								Container: "app",
+								Name:      v1.ResourceCPU,
+								Current: v2.MetricValueStatus{
+									AverageUtilization: ptr.To[int32](0),
+									AverageValue:       resource.NewQuantity(0, resource.DecimalSI),
+									Value:              resource.NewQuantity(0, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+			},
+			emergencyModeGracePeriod: 1 * time.Minute, // Short grace period
+			expected:                 false,           // Should trigger emergency mode
+			description:              "Short grace period should allow emergency mode to trigger sooner",
+		},
+		{
+			name:     "No failure condition - should work normally",
+			tortoise: horizontalTortoise,
+			hpa: &v2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hpa",
+					Namespace: "default",
+				},
+				Status: v2.HorizontalPodAutoscalerStatus{
+					Conditions: []v2.HorizontalPodAutoscalerCondition{
+						{
+							Type:               v2.ScalingActive,
+							Status:             "True", // Working normally
+							Reason:             "ValidMetricFound",
+							Message:            "the HPA was able to successfully calculate a replica count",
+							LastTransitionTime: metav1.NewTime(now.Add(-1 * time.Minute)),
+						},
+					},
+					CurrentMetrics: []v2.MetricStatus{
+						{
+							Type: "ContainerResource",
+							ContainerResource: &v2.ContainerResourceMetricStatus{
+								Container: "app",
+								Name:      v1.ResourceCPU,
+								Current: v2.MetricValueStatus{
+									AverageUtilization: ptr.To[int32](50), // Normal utilization
+									AverageValue:       resource.NewQuantity(100, resource.DecimalSI),
+									Value:              resource.NewQuantity(100, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+			},
+			emergencyModeGracePeriod: 5 * time.Minute,
+			expected:                 true, // Should work normally
+			description:              "Normal HPA operation should not be affected by grace period",
+		},
+		{
+			name:     "Multiple failure conditions - should respect grace period for all",
+			tortoise: horizontalTortoise,
+			hpa: &v2.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-hpa",
+					Namespace: "default",
+				},
+				Status: v2.HorizontalPodAutoscalerStatus{
+					Conditions: []v2.HorizontalPodAutoscalerCondition{
+						{
+							Type:               v2.ScalingActive,
+							Status:             "False",
+							Reason:             "FailedGetResourceMetric",
+							Message:            "failed to get cpu utilization",
+							LastTransitionTime: metav1.NewTime(now.Add(-10 * time.Minute)), // Old failure
+						},
+						{
+							Type:               v2.AbleToScale,
+							Status:             "False",
+							Reason:             "FailedGetScale",
+							Message:            "failed to get scale",
+							LastTransitionTime: metav1.NewTime(now.Add(-2 * time.Minute)), // Recent failure
+						},
+					},
+					CurrentMetrics: []v2.MetricStatus{
+						{
+							Type: "ContainerResource",
+							ContainerResource: &v2.ContainerResourceMetricStatus{
+								Container: "app",
+								Name:      v1.ResourceCPU,
+								Current: v2.MetricValueStatus{
+									AverageUtilization: ptr.To[int32](0),
+									AverageValue:       resource.NewQuantity(0, resource.DecimalSI),
+									Value:              resource.NewQuantity(0, resource.DecimalSI),
+								},
+							},
+						},
+					},
+				},
+			},
+			emergencyModeGracePeriod: 5 * time.Minute,
+			expected:                 false, // Should trigger emergency mode due to old condition
+			description:              "With multiple conditions, should trigger emergency if any are beyond grace period",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create service with the specified grace period
+			c, err := New(
+				fake.NewClientBuilder().Build(),
+				record.NewFakeRecorder(10),
+				0.95, 90, 100,
+				time.Hour,
+				nil,
+				100, 1000, 3,
+				"",
+				tt.emergencyModeGracePeriod,
+			)
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			result := c.IsHpaMetricAvailable(context.Background(), tt.tortoise, tt.hpa)
+
+			if result != tt.expected {
+				t.Errorf("Test '%s' failed: %s\nExpected: %v, Got: %v",
+					tt.name, tt.description, tt.expected, result)
 			}
 		})
 	}

--- a/pkg/hpa/service_test.go
+++ b/pkg/hpa/service_test.go
@@ -20,6 +20,10 @@ import (
 	"github.com/mercari/tortoise/api/v1beta3"
 )
 
+const (
+	defaultEmergencyModeGracePeriod = 5 * time.Minute
+)
+
 func TestClient_UpdateHPAFromTortoiseRecommendation(t *testing.T) {
 	now := metav1.NewTime(time.Date(2022, 1, 1, 1, 1, 1, 1, time.UTC))
 
@@ -5326,8 +5330,8 @@ func TestService_IsHpaMetricAvailable_EmergencyModeGracePeriod(t *testing.T) {
 					},
 				},
 			},
-			emergencyModeGracePeriod: 5 * time.Minute, // Grace period longer than failure time
-			expected:                 true,            // Should NOT trigger emergency mode
+			emergencyModeGracePeriod: defaultEmergencyModeGracePeriod, // Grace period longer than failure time
+			expected:                 true,                            // Should NOT trigger emergency mode
 			description:              "Recent failure within grace period should return true (no emergency)",
 		},
 		{
@@ -5364,8 +5368,8 @@ func TestService_IsHpaMetricAvailable_EmergencyModeGracePeriod(t *testing.T) {
 					},
 				},
 			},
-			emergencyModeGracePeriod: 5 * time.Minute, // Grace period shorter than failure time
-			expected:                 false,           // Should trigger emergency mode
+			emergencyModeGracePeriod: defaultEmergencyModeGracePeriod, // Grace period shorter than failure time
+			expected:                 false,                           // Should trigger emergency mode
 			description:              "Old failure beyond grace period should return false (trigger emergency)",
 		},
 		{
@@ -5440,7 +5444,7 @@ func TestService_IsHpaMetricAvailable_EmergencyModeGracePeriod(t *testing.T) {
 					},
 				},
 			},
-			emergencyModeGracePeriod: 5 * time.Minute,
+			emergencyModeGracePeriod: defaultEmergencyModeGracePeriod,
 			expected:                 true, // Should work normally
 			description:              "Normal HPA operation should not be affected by grace period",
 		},
@@ -5485,7 +5489,7 @@ func TestService_IsHpaMetricAvailable_EmergencyModeGracePeriod(t *testing.T) {
 					},
 				},
 			},
-			emergencyModeGracePeriod: 5 * time.Minute,
+			emergencyModeGracePeriod: defaultEmergencyModeGracePeriod,
 			expected:                 false, // Should trigger emergency mode due to old condition
 			description:              "With multiple conditions, should trigger emergency if any are beyond grace period",
 		},


### PR DESCRIPTION
This pull request introduces a configurable "emergency mode grace period" for the HPA (Horizontal Pod Autoscaler) service, ensuring that temporary metric unavailability does not immediately trigger emergency mode. The changes add this new parameter to the `Service` struct and its constructor, update all usages and test cases accordingly, and enhance the logic for determining HPA metric availability. Additionally, a comprehensive set of unit tests is added to verify the new grace period behavior.

**HPA Emergency Mode Grace Period Feature:**

* Added an `emergencyModeGracePeriod` field to the `Service` struct in `pkg/hpa/service.go`, and updated the `New` constructor to accept this parameter, defaulting to 5 minutes if not provided. This grace period prevents false emergency mode triggers during temporary HPA metric unavailability. [[1]](diffhunk://#diff-4b27fb21b4dbba4158ce4d4076b9d63588e02c73b6a5a128585aae1f542399a4R45) [[2]](diffhunk://#diff-4b27fb21b4dbba4158ce4d4076b9d63588e02c73b6a5a128585aae1f542399a4R80) [[3]](diffhunk://#diff-4b27fb21b4dbba4158ce4d4076b9d63588e02c73b6a5a128585aae1f542399a4R97-R102) [[4]](diffhunk://#diff-4b27fb21b4dbba4158ce4d4076b9d63588e02c73b6a5a128585aae1f542399a4R115)
* Updated all instantiations of the HPA service in production code and tests to pass the new `emergencyModeGracePeriod` parameter. [[1]](diffhunk://#diff-38766201f9a3d5c0ac13dc5ed4e3da2f0487ad4fc8111b267f4ee4915afa143bL171-R171) [[2]](diffhunk://#diff-c444f711e9191b53952edb65bfd8c644419fc7695c62611dc0fb304b4fb197d6L155-R155) [[3]](diffhunk://#diff-33454b01dce1dec0c8bf837d656758a0036ee52f5650a7571586fbf22d156cc8L262-R262) [[4]](diffhunk://#diff-99a73a4c4c24a5813001d63efd63a6ef93f0589b16560136f63ad246c48eaf1bL2753-R2753) [[5]](diffhunk://#diff-99a73a4c4c24a5813001d63efd63a6ef93f0589b16560136f63ad246c48eaf1bL3066-R3071) [[6]](diffhunk://#diff-99a73a4c4c24a5813001d63efd63a6ef93f0589b16560136f63ad246c48eaf1bL4624-R4629) [[7]](diffhunk://#diff-99a73a4c4c24a5813001d63efd63a6ef93f0589b16560136f63ad246c48eaf1bL5253-R5253)

**Logic Improvements:**

* Enhanced the `IsHpaMetricAvailable` method to apply the grace period before switching to emergency mode, and improved the check for valid metrics by aggregating results instead of returning early. [[1]](diffhunk://#diff-4b27fb21b4dbba4158ce4d4076b9d63588e02c73b6a5a128585aae1f542399a4R797-R799) [[2]](diffhunk://#diff-4b27fb21b4dbba4158ce4d4076b9d63588e02c73b6a5a128585aae1f542399a4L807-R854)

**Testing:**

* Added a new, thorough unit test (`TestService_IsHpaMetricAvailable_EmergencyModeGracePeriod`) to cover various scenarios for the emergency mode grace period, ensuring correct behavior for recent and old failures, short grace periods, normal operation, and multiple failure conditions.

**Minor Code Maintenance:**

* Cleaned up imports and ensured consistent usage of the `autoscalingv1beta3` alias for API types. [[1]](diffhunk://#diff-4b27fb21b4dbba4158ce4d4076b9d63588e02c73b6a5a128585aae1f542399a4L26) [[2]](diffhunk://#diff-4b27fb21b4dbba4158ce4d4076b9d63588e02c73b6a5a128585aae1f542399a4L223-R231) [[3]](diffhunk://#diff-4b27fb21b4dbba4158ce4d4076b9d63588e02c73b6a5a128585aae1f542399a4L355-R363) [[4]](diffhunk://#diff-4b27fb21b4dbba4158ce4d4076b9d63588e02c73b6a5a128585aae1f542399a4L707-R715)

These changes make the HPA service more robust to transient metric issues and improve test coverage for emergency mode scenarios.