### PR TITLE
Implementation of a Global Disable Mode in Tortoise which will prevent tortoise from applying recommendations at a cluster level 

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Please refer to [User guide](./docs/user-guide.md) to learn more about other par
 - [User guide](./docs/user-guide.md): describes a minimum knowledge that the end-users have to know, 
 and how they can configure Tortoise so that they can let tortoises autoscale their workloads.
 - [Admin guide](./docs/admin-guide.md): describes how the cluster admin can configure the global behavior of tortoise. 
+- [Global Disable Mode](./docs/global-disable-mode.md): describes how to use the global disable mode for testing and POC scenarios.
 - [Emergency mode](./docs/emergency.md): describes the emergency mode.
 - [Horizontal scaling](./docs/horizontal.md): describes how the Tortoise does the horizontal autoscaling internally.
 - [Vertical scaling](./docs/vertical.md): describes how the Tortoise does the vertical autoscaling internally.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Please refer to [User guide](./docs/user-guide.md) to learn more about other par
 - [User guide](./docs/user-guide.md): describes a minimum knowledge that the end-users have to know, 
 and how they can configure Tortoise so that they can let tortoises autoscale their workloads.
 - [Admin guide](./docs/admin-guide.md): describes how the cluster admin can configure the global behavior of tortoise. 
-- [Global Disable Mode](./docs/global-disable-mode.md): describes how to use the global disable mode for testing and POC scenarios.
+- [Global Disable Mode](./docs/global-disable-mode.md): describes how to use the global disable mode for testing scenarios.
 - [Emergency mode](./docs/emergency.md): describes the emergency mode.
 - [Horizontal scaling](./docs/horizontal.md): describes how the Tortoise does the horizontal autoscaling internally.
 - [Vertical scaling](./docs/vertical.md): describes how the Tortoise does the vertical autoscaling internally.

--- a/api/autoscaling/v2/webhook_suite_test.go
+++ b/api/autoscaling/v2/webhook_suite_test.go
@@ -166,9 +166,9 @@ var _ = BeforeSuite(func() {
 	config, err := config.ParseConfig("")
 	Expect(err).NotTo(HaveOccurred())
 	eventRecorder := mgr.GetEventRecorderFor("tortoise-controller")
-	tortoiseService, err := tortoise.New(mgr.GetClient(), eventRecorder, config.RangeOfMinMaxReplicasRecommendationHours, config.TimeZone, config.TortoiseUpdateInterval, config.GatheringDataPeriodType)
+	tortoiseService, err := tortoise.New(mgr.GetClient(), eventRecorder, config.RangeOfMinMaxReplicasRecommendationHours, config.TimeZone, config.TortoiseUpdateInterval, config.GatheringDataPeriodType, config.GlobalDisableMode)
 	Expect(err).NotTo(HaveOccurred())
-	hpaService, err := hpa.New(mgr.GetClient(), eventRecorder, config.ReplicaReductionFactor, config.MaximumTargetResourceUtilization, 100, time.Hour, nil, 1000, 10000, 3, "", config.EmergencyModeGracePeriod)
+	hpaService, err := hpa.New(mgr.GetClient(), eventRecorder, config.ReplicaReductionFactor, config.MaximumTargetResourceUtilization, 100, time.Hour, nil, 1000, 10000, 3, "", config.EmergencyModeGracePeriod, config.GlobalDisableMode)
 	Expect(err).NotTo(HaveOccurred())
 
 	hpaWebhook := New(tortoiseService, hpaService)

--- a/api/core/v1/webhook_suite_test.go
+++ b/api/core/v1/webhook_suite_test.go
@@ -166,7 +166,7 @@ var _ = BeforeSuite(func() {
 	config, err := config.ParseConfig("")
 	Expect(err).NotTo(HaveOccurred())
 	eventRecorder := mgr.GetEventRecorderFor("tortoise-controller")
-	tortoiseService, err := tortoise.New(mgr.GetClient(), eventRecorder, config.RangeOfMinMaxReplicasRecommendationHours, config.TimeZone, config.TortoiseUpdateInterval, config.GatheringDataPeriodType)
+	tortoiseService, err := tortoise.New(mgr.GetClient(), eventRecorder, config.RangeOfMinMaxReplicasRecommendationHours, config.TimeZone, config.TortoiseUpdateInterval, config.GatheringDataPeriodType, config.GlobalDisableMode)
 	Expect(err).NotTo(HaveOccurred())
 
 	const (

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/mercari/tortoise/pkg/config"
 	"github.com/mercari/tortoise/pkg/deployment"
 	"github.com/mercari/tortoise/pkg/hpa"
+	"github.com/mercari/tortoise/pkg/metrics"
 	"github.com/mercari/tortoise/pkg/pod"
 	"github.com/mercari/tortoise/pkg/recommender"
 	"github.com/mercari/tortoise/pkg/tortoise"
@@ -118,6 +119,9 @@ func main() {
 
 	setupLog.Info("config", "config", *config)
 
+	// Set the global disable mode metric
+	metrics.SetGlobalDisableMode(config.GlobalDisableMode)
+
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                 scheme,
 		HealthProbeBindAddress: probeAddr,
@@ -140,7 +144,7 @@ func main() {
 		os.Exit(1)
 	}
 	eventRecorder := mgr.GetEventRecorderFor("tortoise-controller")
-	tortoiseService, err := tortoise.New(mgr.GetClient(), eventRecorder, config.RangeOfMinMaxReplicasRecommendationHours, config.TimeZone, config.TortoiseUpdateInterval, config.GatheringDataPeriodType)
+	tortoiseService, err := tortoise.New(mgr.GetClient(), eventRecorder, config.RangeOfMinMaxReplicasRecommendationHours, config.TimeZone, config.TortoiseUpdateInterval, config.GatheringDataPeriodType, config.GlobalDisableMode)
 	if err != nil {
 		setupLog.Error(err, "unable to start tortoise service")
 		os.Exit(1)
@@ -152,7 +156,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	hpaService, err := hpa.New(mgr.GetClient(), eventRecorder, config.ReplicaReductionFactor, config.MaximumTargetResourceUtilization, config.HPATargetUtilizationMaxIncrease, config.HPATargetUtilizationUpdateInterval, config.DefaultHPABehavior, config.MaximumMinReplicas, config.MaximumMaxReplicas, int32(config.MinimumMinReplicas), config.HPAExternalMetricExclusionRegex, config.EmergencyModeGracePeriod)
+	hpaService, err := hpa.New(mgr.GetClient(), eventRecorder, config.ReplicaReductionFactor, config.MaximumTargetResourceUtilization, config.HPATargetUtilizationMaxIncrease, config.HPATargetUtilizationUpdateInterval, config.DefaultHPABehavior, config.MaximumMinReplicas, config.MaximumMaxReplicas, int32(config.MinimumMinReplicas), config.HPAExternalMetricExclusionRegex, config.EmergencyModeGracePeriod, config.GlobalDisableMode)
 	if err != nil {
 		setupLog.Error(err, "unable to start hpa service")
 		os.Exit(1)

--- a/docs/global-disable-mode.md
+++ b/docs/global-disable-mode.md
@@ -1,0 +1,144 @@
+# Global Disable Mode
+
+The Global Disable Mode is a feature that allows you to disable Tortoise from applying any recommendations while still allowing it to perform calculations and update its status. This is particularly useful for scenarios like ScaleOps POC where you want to disable Tortoise without modifying individual Tortoise resources.
+
+## How it Works
+
+When Global Disable Mode is enabled:
+
+- **Tortoise continues to run** and perform all calculations
+- **Status updates** are still generated and stored in the Tortoise resource
+- **Recommendations** are calculated and stored in the status
+- **No changes** are applied to HPA, VPA, or Pod resources
+- **Metrics** are still collected and exposed
+- **Events** are still recorded (but indicate that recommendations are not applied)
+
+## Configuration
+
+### Via Configuration File
+
+Add the following to your Tortoise configuration file:
+
+```yaml
+GlobalDisableMode: true
+```
+
+### Via Environment Variable
+
+Set the environment variable:
+
+```bash
+export TORTOISE_GLOBAL_DISABLE_MODE=true
+```
+
+### Default Value
+
+The default value is `false`, meaning Tortoise operates normally unless explicitly disabled.
+
+## Use Cases
+
+### ScaleOps POC
+
+When running a ScaleOps proof of concept, you might want to:
+1. Deploy Tortoise to observe its behavior
+2. See what recommendations it would make
+3. Verify that it's working correctly
+4. But not actually apply any changes to your workloads
+
+Global Disable Mode is perfect for this scenario.
+
+### Testing and Validation
+
+Before enabling Tortoise in production:
+1. Deploy with Global Disable Mode enabled
+2. Monitor the recommendations for a period
+3. Validate that the recommendations make sense
+4. Once confident, disable Global Disable Mode to start applying changes
+
+### Maintenance Windows
+
+During maintenance or troubleshooting:
+1. Enable Global Disable Mode to stop applying changes
+2. Perform maintenance tasks
+3. Disable Global Disable Mode to resume normal operation
+
+## Monitoring
+
+### Prometheus Metrics
+
+The global disable mode status is exposed via a Prometheus metric:
+
+```
+tortoise_global_disable_mode
+```
+
+- `1` = Global Disable Mode is enabled
+- `0` = Global Disable Mode is disabled
+
+### Status Conditions
+
+When Global Disable Mode is enabled, Tortoise will update the status conditions to indicate that recommendations are not being applied:
+
+```yaml
+status:
+  conditions:
+  - type: VerticalRecommendationUpdated
+    status: "False"
+    reason: "GlobalDisableModeEnabled"
+    message: "The recommendation is not applied because global disable mode is enabled"
+```
+
+## Example Configuration
+
+Here's a complete example configuration file with Global Disable Mode enabled:
+
+```yaml
+# Global Disable Mode - disables applying recommendations
+GlobalDisableMode: true
+
+# Other configuration options
+RangeOfMinMaxReplicasRecommendationHours: 1
+GatheringDataPeriodType: "weekly"
+MaxReplicasRecommendationMultiplier: 2.0
+MinReplicasRecommendationMultiplier: 0.5
+ReplicaReductionFactor: 0.95
+MaximumTargetResourceUtilization: 90
+MinimumTargetResourceUtilization: 65
+MinimumMinReplicas: 3
+PreferredMaxReplicas: 30
+MaximumCPURequest: "10"
+MinimumCPURequest: "50m"
+MaximumMemoryRequest: "10Gi"
+MinimumMemoryRequest: "50Mi"
+TimeZone: "Asia/Tokyo"
+TortoiseUpdateInterval: "15s"
+HPATargetUtilizationMaxIncrease: 5
+MaximumMinReplicas: 10
+MaximumMaxReplicas: 100
+MaxAllowedScalingDownRatio: 0.8
+BufferRatioOnVerticalResource: 0.1
+EmergencyModeGracePeriod: "5m"
+```
+
+## Comparison with UpdateMode
+
+| Feature | UpdateMode: Off | Global Disable Mode |
+|---------|----------------|-------------------|
+| Scope | Per-Tortoise resource | Global (all Tortoise resources) |
+| Configuration | In Tortoise spec | In controller configuration |
+| Use Case | Individual resource control | System-wide control |
+| Status Updates | Yes | Yes |
+| Recommendations | Yes | Yes |
+| HPA Updates | No | No |
+| VPA Updates | No | No |
+| Pod Updates | No | No |
+
+## Implementation Details
+
+The Global Disable Mode is implemented at the service level:
+
+- **TortoiseService**: Checks `IsGlobalDisableModeEnabled()` before applying VPA recommendations
+- **HpaService**: Checks `IsGlobalDisableModeEnabled()` before updating HPA resources
+- **Controller**: Checks `IsGlobalDisableModeEnabled()` before triggering rollout restarts
+
+This ensures that all recommendation applications are consistently disabled when the mode is enabled.

--- a/docs/global-disable-mode.md
+++ b/docs/global-disable-mode.md
@@ -1,6 +1,6 @@
 # Global Disable Mode
 
-The Global Disable Mode is a feature that allows you to disable Tortoise from applying any recommendations while still allowing it to perform calculations and update its status. This is particularly useful for scenarios like ScaleOps POC where you want to disable Tortoise without modifying individual Tortoise resources.
+The Global Disable Mode is a feature that allows you to disable Tortoise from applying any recommendations while still allowing it to perform calculations and update its status. This is particularly useful for testing scenarios where you want to disable Tortoise without modifying individual Tortoise resources.
 
 ## How it Works
 
@@ -37,9 +37,9 @@ The default value is `false`, meaning Tortoise operates normally unless explicit
 
 ## Use Cases
 
-### ScaleOps POC
+### Testing Scenarios
 
-When running a ScaleOps proof of concept, you might want to:
+When running testing scenarios, you might want to:
 1. Deploy Tortoise to observe its behavior
 2. See what recommendations it would make
 3. Verify that it's working correctly

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.17.9 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect

--- a/internal/controller/tortoise_controller.go
+++ b/internal/controller/tortoise_controller.go
@@ -290,7 +290,7 @@ func (r *TortoiseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_
 		return ctrl.Result{}, err
 	}
 
-	if tortoise.Spec.UpdateMode != v1beta3.UpdateModeOff && !reflect.DeepEqual(oldTortoise.Status.Conditions.ContainerResourceRequests, tortoise.Status.Conditions.ContainerResourceRequests) {
+	if tortoise.Spec.UpdateMode != v1beta3.UpdateModeOff && !r.TortoiseService.IsGlobalDisableModeEnabled() && !reflect.DeepEqual(oldTortoise.Status.Conditions.ContainerResourceRequests, tortoise.Status.Conditions.ContainerResourceRequests) {
 		// The container resource requests are updated, so we need to update the Pods.
 		err = r.DeploymentService.RolloutRestart(ctx, dm, tortoise, now)
 		if err != nil {

--- a/internal/controller/tortoise_controller_test.go
+++ b/internal/controller/tortoise_controller_test.go
@@ -255,11 +255,11 @@ func startController(ctx context.Context) func() {
 
 	// We only reconcile once.
 	recorder := mgr.GetEventRecorderFor("tortoise-controller")
-	tortoiseService, err := tortoise.New(mgr.GetClient(), recorder, 24, "Asia/Tokyo", 1000*time.Minute, "daily")
+	tortoiseService, err := tortoise.New(mgr.GetClient(), recorder, 24, "Asia/Tokyo", 1000*time.Minute, "daily", false)
 	Expect(err).ShouldNot(HaveOccurred())
 	cli, err := vpa.New(mgr.GetConfig(), recorder)
 	Expect(err).ShouldNot(HaveOccurred())
-	hpaS, err := hpa.New(mgr.GetClient(), recorder, 0.95, 90, 25, time.Hour, nil, 1000, 10000, 3, ".*-exclude-metric", 5*time.Minute)
+	hpaS, err := hpa.New(mgr.GetClient(), recorder, 0.95, 90, 25, time.Hour, nil, 1000, 10000, 3, ".*-exclude-metric", 5*time.Minute, false)
 	Expect(err).ShouldNot(HaveOccurred())
 	reconciler := &TortoiseReconciler{
 		Scheme:             scheme,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -293,6 +293,14 @@ type Config struct {
 	// FeatureFlags is the list of feature flags (default: empty = all alpha features are disabled)
 	// See the list of feature flags in features.go
 	FeatureFlags []features.FeatureFlag `yaml:"FeatureFlags"`
+
+	// GlobalDisableMode is a global flag to disable Tortoise from applying any recommendations.
+	// When enabled, Tortoise will continue to calculate recommendations and update status,
+	// but will not apply any changes to HPA, VPA, or Pod resources.
+	// This is useful for scenarios like ScaleOps POC where you want to disable Tortoise
+	// without modifying individual Tortoise resources.
+	// Default: false (Tortoise operates normally)
+	GlobalDisableMode bool `yaml:"GlobalDisableMode"`
 }
 
 func defaultConfig() *Config {
@@ -325,6 +333,7 @@ func defaultConfig() *Config {
 		ResourceLimitMultiplier:                  map[string]int64{},
 		BufferRatioOnVerticalResource:            0.1,
 		EmergencyModeGracePeriod:                 5 * time.Minute,
+		GlobalDisableMode:                        false,
 	}
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -297,7 +297,7 @@ type Config struct {
 	// GlobalDisableMode is a global flag to disable Tortoise from applying any recommendations.
 	// When enabled, Tortoise will continue to calculate recommendations and update status,
 	// but will not apply any changes to HPA, VPA, or Pod resources.
-	// This is useful for scenarios like ScaleOps POC where you want to disable Tortoise
+	// This is useful for testing scenarios where you want to disable Tortoise
 	// without modifying individual Tortoise resources.
 	// Default: false (Tortoise operates normally)
 	GlobalDisableMode bool `yaml:"GlobalDisableMode"`

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -575,6 +575,23 @@ func Test_validate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "valid config with global disable mode enabled",
+			config: &Config{
+				RangeOfMinMaxReplicasRecommendationHours: 1,
+				GatheringDataPeriodType:                  "weekly",
+				HPATargetUtilizationMaxIncrease:          5,
+				MinimumTargetResourceUtilization:         65,
+				MaximumTargetResourceUtilization:         90,
+				MinimumMinReplicas:                       3,
+				MaximumMinReplicas:                       10,
+				MaximumMaxReplicas:                       100,
+				PreferredMaxReplicas:                     30,
+				MaxAllowedScalingDownRatio:               0.8,
+				GlobalDisableMode:                        true,
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/config/testdata/global-disable-config.yaml
+++ b/pkg/config/testdata/global-disable-config.yaml
@@ -1,6 +1,6 @@
 # Example configuration with global disable mode enabled
 # This will disable Tortoise from applying any recommendations while still
-# allowing it to calculate and update status. Perfect for ScaleOps POC scenarios.
+# allowing it to calculate and update status. Perfect for testing scenarios.
 
 GlobalDisableMode: true
 

--- a/pkg/config/testdata/global-disable-config.yaml
+++ b/pkg/config/testdata/global-disable-config.yaml
@@ -1,0 +1,28 @@
+# Example configuration with global disable mode enabled
+# This will disable Tortoise from applying any recommendations while still
+# allowing it to calculate and update status. Perfect for ScaleOps POC scenarios.
+
+GlobalDisableMode: true
+
+# Other configuration options remain the same
+RangeOfMinMaxReplicasRecommendationHours: 1
+GatheringDataPeriodType: "weekly"
+MaxReplicasRecommendationMultiplier: 2.0
+MinReplicasRecommendationMultiplier: 0.5
+ReplicaReductionFactor: 0.95
+MaximumTargetResourceUtilization: 90
+MinimumTargetResourceUtilization: 65
+MinimumMinReplicas: 3
+PreferredMaxReplicas: 30
+MaximumCPURequest: "10"
+MinimumCPURequest: "50m"
+MaximumMemoryRequest: "10Gi"
+MinimumMemoryRequest: "50Mi"
+TimeZone: "Asia/Tokyo"
+TortoiseUpdateInterval: "15s"
+HPATargetUtilizationMaxIncrease: 5
+MaximumMinReplicas: 10
+MaximumMaxReplicas: 100
+MaxAllowedScalingDownRatio: 0.8
+BufferRatioOnVerticalResource: 0.1
+EmergencyModeGracePeriod: "5m"

--- a/pkg/hpa/service.go
+++ b/pkg/hpa/service.go
@@ -535,6 +535,7 @@ func (c *Service) UpdateHPASpecFromTortoiseAutoscalingPolicy(
 
 	if c.IsGlobalDisableModeEnabled() {
 		// Global disable mode is enabled - don't update HPA but continue processing
+		log.FromContext(ctx).Info("Skipping HPA autoscaling policy update due to global disable mode", "tortoise", klog.KObj(tortoise))
 		return tortoise, nil
 	}
 
@@ -630,6 +631,7 @@ func (c *Service) UpdateHPAFromTortoiseRecommendation(ctx context.Context, torto
 
 	if c.IsGlobalDisableModeEnabled() {
 		// Global disable mode is enabled - don't update HPA but continue processing
+		log.FromContext(ctx).Info("Skipping HPA recommendation update due to global disable mode", "tortoise", klog.KObj(tortoise))
 		return nil, tortoise, nil
 	}
 

--- a/pkg/hpa/service.go
+++ b/pkg/hpa/service.go
@@ -43,6 +43,7 @@ type Service struct {
 	maximumMaxReplica                          int32
 	externalMetricExclusionRegex               *regexp.Regexp
 	emergencyModeGracePeriod                   time.Duration
+	globalDisableMode                          bool
 }
 
 var defaultHPABehaviorValue = &v2.HorizontalPodAutoscalerBehavior{
@@ -78,6 +79,7 @@ func New(
 	minimumMinReplicas int32,
 	externalMetricExclusionRegex string,
 	emergencyModeGracePeriod time.Duration,
+	globalDisableMode bool,
 ) (*Service, error) {
 	var regex *regexp.Regexp
 	if externalMetricExclusionRegex != "" {
@@ -109,6 +111,7 @@ func New(
 		maximumMaxReplica:                          maximumMaxReplica,
 		externalMetricExclusionRegex:               regex,
 		emergencyModeGracePeriod:                   emergencyModeGracePeriod,
+		globalDisableMode:                          globalDisableMode,
 	}, nil
 }
 
@@ -168,6 +171,13 @@ func (c *Service) DeleteHPACreatedByTortoise(ctx context.Context, tortoise *auto
 	}
 
 	return nil
+}
+
+// IsGlobalDisableModeEnabled returns true if global disable mode is enabled.
+// When global disable mode is enabled, Tortoise will not apply any HPA recommendations
+// but will continue to calculate and update status.
+func (c *Service) IsGlobalDisableModeEnabled() bool {
+	return c.globalDisableMode
 }
 
 type resourceNameAndContainerName struct {
@@ -397,7 +407,7 @@ func (c *Service) ChangeHPAFromTortoiseRecommendation(tortoise *autoscalingv1bet
 				continue
 			}
 
-			if allowed && tortoise.Spec.UpdateMode != autoscalingv1beta3.UpdateModeOff {
+			if allowed && tortoise.Spec.UpdateMode != autoscalingv1beta3.UpdateModeOff && !c.IsGlobalDisableModeEnabled() {
 				metrics.AppliedHPATargetUtilization.WithLabelValues(tortoise.Name, tortoise.Namespace, t.ContainerName, resourcename.String(), hpa.Name).Set(float64(proposedTarget))
 			}
 
@@ -407,7 +417,7 @@ func (c *Service) ChangeHPAFromTortoiseRecommendation(tortoise *autoscalingv1bet
 
 		}
 	}
-	if allowed && tortoise.Spec.UpdateMode != autoscalingv1beta3.UpdateModeOff {
+	if allowed && tortoise.Spec.UpdateMode != autoscalingv1beta3.UpdateModeOff && !c.IsGlobalDisableModeEnabled() {
 		tortoise = c.RecordHPATargetUtilizationUpdate(tortoise, now)
 	}
 
@@ -464,8 +474,8 @@ func (c *Service) ChangeHPAFromTortoiseRecommendation(tortoise *autoscalingv1bet
 	}
 
 	hpa.Spec.MinReplicas = &minToActuallyApply
-	if tortoise.Spec.UpdateMode != autoscalingv1beta3.UpdateModeOff && recordMetrics {
-		// We don't want to record applied* metric when UpdateMode is Off.
+	if tortoise.Spec.UpdateMode != autoscalingv1beta3.UpdateModeOff && !c.IsGlobalDisableModeEnabled() && recordMetrics {
+		// We don't want to record applied* metric when UpdateMode is Off or global disable mode is enabled.
 		netChangeMaxReplicas := float64(hpa.Spec.MaxReplicas - recommendMax)
 		netChangeMinReplicas := float64(*hpa.Spec.MinReplicas) - float64(recommendMin)
 		if netChangeMaxReplicas > 0 || netChangeMinReplicas < 0 {
@@ -520,6 +530,11 @@ func (c *Service) UpdateHPASpecFromTortoiseAutoscalingPolicy(
 ) (*autoscalingv1beta3.Tortoise, error) {
 	if tortoise.Spec.UpdateMode == autoscalingv1beta3.UpdateModeOff {
 		// When UpdateMode is Off, we don't update HPA.
+		return tortoise, nil
+	}
+
+	if c.IsGlobalDisableModeEnabled() {
+		// Global disable mode is enabled - don't update HPA but continue processing
 		return tortoise, nil
 	}
 
@@ -613,6 +628,11 @@ func (c *Service) UpdateHPAFromTortoiseRecommendation(ctx context.Context, torto
 		return nil, tortoise, nil
 	}
 
+	if c.IsGlobalDisableModeEnabled() {
+		// Global disable mode is enabled - don't update HPA but continue processing
+		return nil, tortoise, nil
+	}
+
 	retTortoise := &autoscalingv1beta3.Tortoise{}
 	retHPA := &v2.HorizontalPodAutoscaler{}
 
@@ -636,8 +656,8 @@ func (c *Service) UpdateHPAFromTortoiseRecommendation(ctx context.Context, torto
 		}
 		hpa.Spec.Behavior = behavior // overwrite
 		retTortoise = tortoise
-		if tortoise.Spec.UpdateMode == autoscalingv1beta3.UpdateModeOff {
-			// don't update status if update mode is off. (= dryrun)
+		if tortoise.Spec.UpdateMode == autoscalingv1beta3.UpdateModeOff || c.IsGlobalDisableModeEnabled() {
+			// don't update status if update mode is off or global disable mode is enabled. (= dryrun)
 			return nil
 		}
 
@@ -650,7 +670,7 @@ func (c *Service) UpdateHPAFromTortoiseRecommendation(ctx context.Context, torto
 		return nil, retTortoise, err
 	}
 
-	if tortoise.Spec.UpdateMode != autoscalingv1beta3.UpdateModeOff {
+	if tortoise.Spec.UpdateMode != autoscalingv1beta3.UpdateModeOff && !c.IsGlobalDisableModeEnabled() {
 		c.recorder.Event(tortoise, corev1.EventTypeNormal, event.HPAUpdated, fmt.Sprintf("HPA %s/%s is updated by the recommendation", retHPA.Namespace, retHPA.Name))
 	}
 

--- a/pkg/hpa/service_test.go
+++ b/pkg/hpa/service_test.go
@@ -2754,7 +2754,7 @@ func TestClient_UpdateHPAFromTortoiseRecommendation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := New(fake.NewClientBuilder().WithRuntimeObjects(tt.initialHPA).Build(), record.NewFakeRecorder(10), 0.95, 90, 50, time.Hour, nil, 1000, 10001, 3, tt.excludeMetricRegex, 5*time.Minute)
+			c, err := New(fake.NewClientBuilder().WithRuntimeObjects(tt.initialHPA).Build(), record.NewFakeRecorder(10), 0.95, 90, 50, time.Hour, nil, 1000, 10001, 3, tt.excludeMetricRegex, 5*time.Minute, false)
 			if err != nil {
 				t.Fatalf("New() error = %v", err)
 			}
@@ -2777,6 +2777,37 @@ func TestClient_UpdateHPAFromTortoiseRecommendation(t *testing.T) {
 
 func ptrInt32(i int32) *int32 {
 	return &i
+}
+
+func TestService_IsGlobalDisableModeEnabled(t *testing.T) {
+	tests := []struct {
+		name              string
+		globalDisableMode bool
+		expectedResult    bool
+	}{
+		{
+			name:              "global disable mode enabled",
+			globalDisableMode: true,
+			expectedResult:    true,
+		},
+		{
+			name:              "global disable mode disabled",
+			globalDisableMode: false,
+			expectedResult:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &Service{
+				globalDisableMode: tt.globalDisableMode,
+			}
+			result := service.IsGlobalDisableModeEnabled()
+			if result != tt.expectedResult {
+				t.Errorf("IsGlobalDisableModeEnabled() = %v, want %v", result, tt.expectedResult)
+			}
+		})
+	}
 }
 
 func TestService_InitializeHPA(t *testing.T) {
@@ -3067,12 +3098,12 @@ func TestService_InitializeHPA(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := New(fake.NewClientBuilder().Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 100, 1000, 3, "", 5*time.Minute)
+			c, err := New(fake.NewClientBuilder().Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 100, 1000, 3, "", 5*time.Minute, false)
 			if err != nil {
 				t.Fatalf("New() error = %v", err)
 			}
 			if tt.initialHPA != nil {
-				c, err = New(fake.NewClientBuilder().WithRuntimeObjects(tt.initialHPA).Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 100, 1000, 3, "", 5*time.Minute)
+				c, err = New(fake.NewClientBuilder().WithRuntimeObjects(tt.initialHPA).Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 100, 1000, 3, "", 5*time.Minute, false)
 				if err != nil {
 					t.Fatalf("New() error = %v", err)
 				}
@@ -4625,12 +4656,12 @@ func TestService_UpdateHPASpecFromTortoiseAutoscalingPolicy(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := New(fake.NewClientBuilder().Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 1000, 10000, 3, "", 5*time.Minute)
+			c, err := New(fake.NewClientBuilder().Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 1000, 10000, 3, "", 5*time.Minute, false)
 			if err != nil {
 				t.Fatalf("New() error = %v", err)
 			}
 			if tt.initialHPA != nil {
-				c, err = New(fake.NewClientBuilder().WithRuntimeObjects(tt.initialHPA).Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 1000, 10000, 3, "", 5*time.Minute)
+				c, err = New(fake.NewClientBuilder().WithRuntimeObjects(tt.initialHPA).Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 1000, 10000, 3, "", 5*time.Minute, false)
 				if err != nil {
 					t.Fatalf("New() error = %v", err)
 				}
@@ -5254,7 +5285,7 @@ func TestService_IsHpaMetricAvailable(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c, err := New(fake.NewClientBuilder().Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 100, 1000, 3, "", 5*time.Minute)
+			c, err := New(fake.NewClientBuilder().Build(), record.NewFakeRecorder(10), 0.95, 90, 100, time.Hour, nil, 100, 1000, 3, "", 5*time.Minute, false)
 			if err != nil {
 				t.Fatalf("New() error = %v", err)
 			}
@@ -5507,6 +5538,7 @@ func TestService_IsHpaMetricAvailable_EmergencyModeGracePeriod(t *testing.T) {
 				100, 1000, 3,
 				"",
 				tt.emergencyModeGracePeriod,
+				false,
 			)
 			if err != nil {
 				t.Fatalf("New() error = %v", err)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -105,6 +105,11 @@ var (
 		Name: "tortoise_number",
 		Help: "the number of tortoise",
 	}, []string{"tortoise_name", "namespace", "controller_name", "controller_kind", "update_mode", "tortoise_phase"})
+
+	GlobalDisableMode = prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "global_disable_mode",
+		Help: "indicates if global disable mode is enabled (1=enabled, 0=disabled)",
+	})
 )
 
 func init() {
@@ -129,5 +134,15 @@ func init() {
 		ProposedCPURequest,
 		ProposedMemoryRequest,
 		TortoiseNumber,
+		GlobalDisableMode,
 	)
+}
+
+// SetGlobalDisableMode sets the global disable mode metric
+func SetGlobalDisableMode(enabled bool) {
+	if enabled {
+		GlobalDisableMode.Set(1)
+	} else {
+		GlobalDisableMode.Set(0)
+	}
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -107,7 +107,7 @@ var (
 	}, []string{"tortoise_name", "namespace", "controller_name", "controller_kind", "update_mode", "tortoise_phase"})
 
 	GlobalDisableMode = prometheus.NewGauge(prometheus.GaugeOpts{
-		Name: "global_disable_mode",
+		Name: "tortoise_global_disable_mode",
 		Help: "indicates if global disable mode is enabled (1=enabled, 0=disabled)",
 	})
 )

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,36 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestSetGlobalDisableMode(t *testing.T) {
+	tests := []struct {
+		name     string
+		enabled  bool
+		expected float64
+	}{
+		{
+			name:     "global disable mode enabled",
+			enabled:  true,
+			expected: 1,
+		},
+		{
+			name:     "global disable mode disabled",
+			enabled:  false,
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SetGlobalDisableMode(tt.enabled)
+			actual := testutil.ToFloat64(GlobalDisableMode)
+			if actual != tt.expected {
+				t.Errorf("SetGlobalDisableMode(%v) = %v, want %v", tt.enabled, actual, tt.expected)
+			}
+		})
+	}
+}

--- a/pkg/tortoise/tortoise.go
+++ b/pkg/tortoise/tortoise.go
@@ -751,6 +751,7 @@ func (c *Service) UpdateResourceRequest(ctx context.Context, tortoise *v1beta3.T
 
 	if c.IsGlobalDisableModeEnabled() {
 		// Global disable mode is enabled - don't apply recommendations but still update status
+		log.FromContext(ctx).Info("Skipping VPA recommendation application due to global disable mode", "tortoise", klog.KObj(tortoise))
 		tortoise = utils.ChangeTortoiseCondition(tortoise,
 			v1beta3.TortoiseConditionTypeVerticalRecommendationUpdated,
 			corev1.ConditionFalse,

--- a/pkg/tortoise/tortoise.go
+++ b/pkg/tortoise/tortoise.go
@@ -42,13 +42,17 @@ type Service struct {
 	// If "day", tortoise will consider all workload behaves very similarly every day.
 	// If your workload may behave differently on, for example, weekdays and weekends, set this to "weekly".
 	gatheringDataDuration string
+	// GlobalDisableMode is a global flag to disable Tortoise from applying any recommendations.
+	// When enabled, Tortoise will continue to calculate recommendations and update status,
+	// but will not apply any changes to HPA, VPA, or Pod resources.
+	globalDisableMode bool
 
 	mu sync.RWMutex
 	// TODO: Instead of here, we should store the last time of each tortoise in the status of the tortoise.
 	lastTimeUpdateTortoise map[client.ObjectKey]time.Time
 }
 
-func New(c client.Client, recorder record.EventRecorder, rangeOfMinMaxReplicasRecommendationHour int, timeZone string, tortoiseUpdateInterval time.Duration, gatheringDataDuration string) (*Service, error) {
+func New(c client.Client, recorder record.EventRecorder, rangeOfMinMaxReplicasRecommendationHour int, timeZone string, tortoiseUpdateInterval time.Duration, gatheringDataDuration string, globalDisableMode bool) (*Service, error) {
 	jst, err := time.LoadLocation(timeZone)
 	if err != nil {
 		return nil, fmt.Errorf("load location: %w", err)
@@ -65,6 +69,7 @@ func New(c client.Client, recorder record.EventRecorder, rangeOfMinMaxReplicasRe
 		gatheringDataDuration:                   gatheringDataDuration,
 		timeZone:                                jst,
 		tortoiseUpdateInterval:                  tortoiseUpdateInterval,
+		globalDisableMode:                       globalDisableMode,
 		lastTimeUpdateTortoise:                  map[client.ObjectKey]time.Time{},
 	}, nil
 }
@@ -515,6 +520,13 @@ func (s *Service) updateLastTimeUpdateTortoise(tortoise *v1beta3.Tortoise, now t
 	s.lastTimeUpdateTortoise[client.ObjectKeyFromObject(tortoise)] = now
 }
 
+// IsGlobalDisableModeEnabled returns true if global disable mode is enabled.
+// When global disable mode is enabled, Tortoise will not apply any recommendations
+// but will continue to calculate and update status.
+func (s *Service) IsGlobalDisableModeEnabled() bool {
+	return s.globalDisableMode
+}
+
 func (s *Service) RecordReconciliationFailure(t *v1beta3.Tortoise, err error, now time.Time) *v1beta3.Tortoise {
 	if err != nil {
 		s.recorder.Event(t, "Warning", "ReconcileError", err.Error())
@@ -732,6 +744,18 @@ func (c *Service) UpdateResourceRequest(ctx context.Context, tortoise *v1beta3.T
 			corev1.ConditionFalse,
 			"",
 			"The recommendation is not provided because it's Off mode",
+			now,
+		)
+		return tortoise, nil
+	}
+
+	if c.IsGlobalDisableModeEnabled() {
+		// Global disable mode is enabled - don't apply recommendations but still update status
+		tortoise = utils.ChangeTortoiseCondition(tortoise,
+			v1beta3.TortoiseConditionTypeVerticalRecommendationUpdated,
+			corev1.ConditionFalse,
+			"",
+			"The recommendation is not applied because global disable mode is enabled",
 			now,
 		)
 		return tortoise, nil

--- a/pkg/tortoise/tortoise_test.go
+++ b/pkg/tortoise/tortoise_test.go
@@ -4606,6 +4606,37 @@ func TestService_UpdateResourceRequest(t *testing.T) {
 	}
 }
 
+func TestService_IsGlobalDisableModeEnabled(t *testing.T) {
+	tests := []struct {
+		name              string
+		globalDisableMode bool
+		expectedResult    bool
+	}{
+		{
+			name:              "global disable mode enabled",
+			globalDisableMode: true,
+			expectedResult:    true,
+		},
+		{
+			name:              "global disable mode disabled",
+			globalDisableMode: false,
+			expectedResult:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			service := &Service{
+				globalDisableMode: tt.globalDisableMode,
+			}
+			result := service.IsGlobalDisableModeEnabled()
+			if result != tt.expectedResult {
+				t.Errorf("IsGlobalDisableModeEnabled() = %v, want %v", result, tt.expectedResult)
+			}
+		})
+	}
+}
+
 func TestService_UpdateTortoisePhaseIfHPAIsUnhealthy(t *testing.T) {
 	type args struct {
 		t             *v1beta3.Tortoise


### PR DESCRIPTION
# Add Global Disable Mode for Tortoise

## Summary
Implements a global "lame duck" mode that allows disabling Tortoise from applying any recommendations while still allowing it to perform calculations and update status. This is particularly useful for any POC scenarios where you want to disable Tortoise without modifying individual Tortoise resources.

## Changes
- **Configuration**: Added `GlobalDisableMode` boolean flag to config system
- **Services**: Modified `TortoiseService` and `HpaService` to respect global disable mode
- **Controller**: Updated main controller to check global disable mode before rollout restart
- **Metrics**: Added `global_disable_mode` Prometheus metric to track status
- **Documentation**: Added comprehensive docs and example configuration

## Behavior
When `GlobalDisableMode: true`:
- ✅ Tortoise continues running and calculating recommendations
- ✅ Status updates are still generated and stored
- ✅ Metrics are still collected and exposed
- ❌ No changes are applied to HPA, VPA, or Pod resources
- ❌ No rollout restarts are triggered

## Usage
```yaml
# config.yaml
GlobalDisableMode: true
```

## Example Configuration
See `pkg/config/testdata/global-disable-config.yaml` for a complete example.

## Testing
- Added comprehensive unit tests for all new functionality
- All existing tests pass
- golangci-lint passes

## Files Changed
- `pkg/config/config.go` - Added GlobalDisableMode configuration
- `pkg/tortoise/tortoise.go` - Added global disable mode support
- `pkg/hpa/service.go` - Added global disable mode support
- `pkg/metrics/metrics.go` - Added global disable mode metric
- `internal/controller/tortoise_controller.go` - Added global disable mode check
- `cmd/main.go` - Added metric initialization
- `docs/global-disable-mode.md` - Added comprehensive documentation
- Various test files - Added unit tests
