### PR TITLE
docs: fix typos and grammar across documentation and source

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ To address these challenges, the platform team has embarked on developing Tortoi
 an automated solution designed to meet all Kubernetes resource optimization needs.
 
 This approach shifts the optimization responsibility from service owners to the platform team (Tortoises), 
-allowing for comprehensive tuning by the platform team to ensure all Tortoises in the cluster adapts to each workload. 
+allowing for comprehensive tuning by the platform team to ensure all Tortoises in the cluster adapt to each workload. 
 On the other hand, service owners are required to configure only a minimal number of parameters 
 to initiate autoscaling with Tortoise, significantly simplifying their involvement.
 

--- a/api/v1beta3/tortoise_types.go
+++ b/api/v1beta3/tortoise_types.go
@@ -179,7 +179,7 @@ type TargetRefs struct {
 	HorizontalPodAutoscalerName *string `json:"horizontalPodAutoscalerName,omitempty" protobuf:"bytes,2,opt,name=horizontalPodAutoscalerName"`
 }
 
-// CrossVersionObjectReference contains enough information toet identify the referred resource.
+// CrossVersionObjectReference contains enough information to let identify the referred resource.
 type CrossVersionObjectReference struct {
 	// kind is the kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`

--- a/docs/contributor-guide.md
+++ b/docs/contributor-guide.md
@@ -18,7 +18,7 @@ If you didn’t add a test, you didn’t fix the bug.
 - **Do not** test anything manually in your Kubernetes cluster. 
 Instead, you **must** implement all testing in the e2e tests.
 - **Do not** bring any breaking change in Tortoise CRD. 
-However, you **may** bring breaking changes in Golang functions or types within the repository - we're not developping the library and don't have to care much about downstream dependencies.
+However, you **may** bring breaking changes in Golang functions or types within the repository - we're not developing the library and don't have to care much about downstream dependencies.
 
 ### Suggestion
 

--- a/docs/horizontal.md
+++ b/docs/horizontal.md
@@ -18,7 +18,7 @@ Currently, Tortoise supports only `type: ContainerResource` metric.
 If HPA has `type: Resource` metrics, Tortoise just removes them because they'd be conflict with `type: ContainerResource` metrics managed by Tortoise.
 If HPA has metrics other than `Resource` or `ContainerResource`, Tortoise just keeps them. 
 
-### How Tortoise 
+### How Tortoise calculates the recommendations
 
 ### MaxReplicas
 
@@ -54,7 +54,7 @@ Supposing your web frontend is down, your backend app Pods would be scaled in be
 But, when your web frontend is back, the huge traffic that the backend app usually handles would come again,
 and if the backend had been scaled in too much, it could be overwhelmed easily.
 
-To prevent this kind of issue like domino, Tortoise sets MinReplicas like above so that it can keep the replica number to some extend, preventing too much scaling in.
+To prevent this kind of issue like domino, Tortoise sets MinReplicas like above so that it can keep the replica number to some extent, preventing too much scaling in.
 
 ### Target utilization
 


### PR DESCRIPTION
#### What this PR does / why we need it:

Fixes a few typos and grammar errors I found while reading through the docs and source comments.

**Changes:**
- [api/v1beta3/tortoise_types.go](cci:7://file:///c:/Projects/tortoise/api/v1beta3/tortoise_types.go:0:0-0:0): "toet" -> "to let" in [CrossVersionObjectReference](cci:2://file:///c:/Projects/tortoise/api/v1beta3/tortoise_types.go:182:0-192:1) comment
- [docs/horizontal.md](cci:7://file:///c:/Projects/tortoise/docs/horizontal.md:0:0-0:0): Completed the cut-off section header "### How Tortoise" -> "### How Tortoise calculates the recommendations"
- [docs/horizontal.md](cci:7://file:///c:/Projects/tortoise/docs/horizontal.md:0:0-0:0): "to some extend" -> "to some extent"
- [docs/contributor-guide.md](cci:7://file:///c:/Projects/tortoise/docs/contributor-guide.md:0:0-0:0): "developping" -> "developing"
- [README.md](cci:7://file:///c:/Projects/tortoise/README.md:0:0-0:0): "adapts" -> "adapt" (subject-verb agreement, since "all Tortoises" is plural)

#### Which issue(s) this PR fixes:

N/A (typo/grammar fixes, no issue needed)

#### Special notes
This is my first contribution to this project. All changes are in docs and comments only, no logic changes.

One thing I noticed but didn't change: in [docs/horizontal.md](cci:7://file:///c:/Projects/tortoise/docs/horizontal.md:0:0-0:0) Examples 3 and 4 (lines 171, 179, 199, 207, 211), replicas of 3 are described as "the same as [PreferredMaxReplicas](cci:1://file:///c:/Projects/tortoise/pkg/recommender/recommender.go:223:0-235:1)", but looking at the context (the section is about reaching the *minimum* replicas, and `MinimumMinReplicas` is 3), I think these should say `MinimumMinReplicas` instead. Left them as-is since I wasn't 100% sure, but wanted to flag it.
